### PR TITLE
Feature/custom 404 handler

### DIFF
--- a/canvas_course_wizard/README.md
+++ b/canvas_course_wizard/README.md
@@ -50,3 +50,16 @@ $vagrant ssh
 Now that the environment is setup you can try running the server:
 
 9) python manage.py runserver 0.0.0.0:8000
+
+### Custom 404 exception handling:
+
+Django will catch 404 exceptions by default and handle them by displaying a project-level 404 page.  They provide a mechanism to customize that page per application.  If you want to handle 404s on a per-view basis though, use the Custom404Mixin class:
+
+```
+from canvas_course_wizard.mixins import Custom404Mixin
+
+class SchoolListView(Custom404Mixin, generic.ListView):
+    template_name_404 = 'path/to/template.html'
+```
+
+The *template_name_404* parameter is required and an ImproperlyConfigured exception will be raised if the template is not defined.  Note, however, that the exception will only be raised at the point where a 404 exception is caught, so you'll want to make sure you verify that parameter is present during the testing phase for your application.

--- a/canvas_course_wizard/mixins.py
+++ b/canvas_course_wizard/mixins.py
@@ -11,6 +11,7 @@ class Custom404Mixin(object):
     to render.  Subclasses can override this method and supply some default values for
     template if a 404 template was not already provided.
     """
+
     def get_404_template_names(self):
         if self.template_name_404 is None:
             raise ImproperlyConfigured(

--- a/canvas_course_wizard/test_custom_404_mixin.py
+++ b/canvas_course_wizard/test_custom_404_mixin.py
@@ -1,0 +1,51 @@
+import unittest
+import mock
+from django.test import RequestFactory
+from .mixins import Custom404Mixin
+from django.core.exceptions import ImproperlyConfigured
+from django.http import Http404
+from django.template.response import TemplateResponse
+
+
+class Custom404MixinTest(unittest.TestCase):
+    longMessage = True
+
+    def setUp(self):
+        self.mixin = Custom404Mixin()
+
+    def test_instance_setup(self):
+        self.assertEqual(self.mixin.template_name_404, None,
+                         "Custom404Mixin should have default template name attribute set to None")
+
+    def test_get_404_template_names_none_template_raises_improperly_configured(self):
+        with self.assertRaises(ImproperlyConfigured):
+            self.mixin.get_404_template_names()
+
+    def test_get_404_template_names_result_matches_template_attribute(self):
+        template_name_404 = 'canvas_course_wizard/my_custom_404_page.html'
+        self.mixin.template_name_404 = template_name_404
+        self.assertEqual(self.mixin.get_404_template_names(), [template_name_404],
+                         "Template result should be a list containing defined class attribute")
+
+    @mock.patch('canvas_course_wizard.mixins.super', create=True)
+    @mock.patch('canvas_course_wizard.mixins.TemplateResponse', spec=TemplateResponse)
+    def test_dispatch_response_when_404_raised(self, template_response_mock, super_mock):
+        request = RequestFactory().get('/fake-path')
+        get_404_template_names_mock = mock.Mock()
+        # Ensure call to super.dispatch raises a 404
+        super_mock.return_value.dispatch.side_effect = Http404
+        self.mixin.get_404_template_names = get_404_template_names_mock
+        response = self.mixin.dispatch(request)
+        self.assertEqual(response, template_response_mock.return_value,
+                         "Return value of dispatch when 404 is raised should be a TemplateResponse()")
+        get_404_template_names_mock.assert_called_once_with()
+        template_response_mock.assert_called_with(status=404, request=request, template=mock.ANY)
+
+    @mock.patch('canvas_course_wizard.mixins.super', create=True)
+    def test_dispatch_response_when_404_not_raised(self, super_mock):
+        request = RequestFactory().get('/fake-path')
+        response = self.mixin.dispatch(request)
+        # Little trick here to ensure that a call to the dispatch method normally
+        # returns the result of super.dispatch
+        self.assertEqual(response, super_mock.return_value.dispatch.return_value,
+                         "Call to dispatch that doesn't raise an exception should return result super().dispatch()")

--- a/canvas_course_wizard/tests.py
+++ b/canvas_course_wizard/tests.py
@@ -1,7 +1,6 @@
 import unittest
 import mock
 from .views import CourseWizardIndexView, CourseIndexView
-from .mixins import Custom404Mixin
 from django.core.urlresolvers import resolve
 from django.views.generic import TemplateView
 from django.views.generic.detail import DetailView
@@ -9,52 +8,6 @@ from braces.views import LoginRequiredMixin
 from django.test import RequestFactory
 from icommons_common.models import CourseInstance
 from django.shortcuts import render
-from django.core.exceptions import ImproperlyConfigured
-from django.http import Http404
-
-
-class Custom404MixinTest(unittest.TestCase):
-    longMessage = True
-
-    def setUp(self):
-        self.mixin = Custom404Mixin()
-
-    def test_instance_setup(self):
-        self.assertEqual(self.mixin.template_name_404, None,
-                         "Custom404Mixin should have default template name attribute set to None")
-
-    def test_get_404_template_names_none_template_raises_improperly_configured(self):
-        with self.assertRaises(ImproperlyConfigured):
-            self.mixin.get_404_template_names()
-
-    def test_get_404_template_names_result_matches_template_attribute(self):
-        template_name_404 = 'canvas_course_wizard/my_custom_404_page.html'
-        self.mixin.template_name_404 = template_name_404
-        self.assertEqual(self.mixin.get_404_template_names(), [template_name_404],
-                         "Template result should be a list containing defined class attribute")
-
-    @mock.patch('canvas_course_wizard.mixins.super', create=True)
-    @mock.patch('canvas_course_wizard.mixins.TemplateResponse')
-    def test_dispatch_response_when_404_raised(self, template_response_mock, super_mock):
-        request = RequestFactory().get('/fake-path')
-        get_404_template_names_mock = mock.Mock()
-        # Ensure call to super.dispatch raises a 404
-        super_mock.return_value.dispatch.side_effect = Http404
-        self.mixin.get_404_template_names = get_404_template_names_mock
-        response = self.mixin.dispatch(request)
-        self.assertEqual(response, template_response_mock,
-                         "Return value of dispatch when 404 is raised should be a TemplateResponse object")
-        get_404_template_names_mock.assert_called_once_with()
-        template_response_mock.assert_called_with(status=404, request=request, template=mock.ANY)
-
-    @mock.patch('canvas_course_wizard.mixins.super', create=True)
-    def test_dispatch_response_when_404_not_raised(self, super_mock):
-        request = RequestFactory().get('/fake-path')
-        response = self.mixin.dispatch(request)
-        # Little trick here to ensure that a call to the dispatch method normally
-        # returns the result of super.dispatch
-        self.assertEqual(response, super_mock.return_value.dispatch.return_value,
-                         "Call to dispatch that doesn't raise an exception should return result super().dispatch()")
 
 
 class CourseWizardIndexViewTest(unittest.TestCase):


### PR DESCRIPTION
Create a custom 404 handler mixin that will render a given template when a 404 exception is raised during a dispatch call.
