### PR TITLE
Feature/admin email settings

### DIFF
--- a/icommons_ext_tools/settings/base.py
+++ b/icommons_ext_tools/settings/base.py
@@ -34,7 +34,7 @@ SERVER_EMAIL = 'iCommons Tools <icommons-bounces@harvard.edu>'
 
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = 'mailhost.harvard.edu'
-#EMAIL_USE_TLS = True
+EMAIL_USE_TLS = True
 
 MANAGERS = ADMINS
 
@@ -112,7 +112,7 @@ TEMPLATE_LOADERS = (
 )
 
 MIDDLEWARE_CLASSES = (
-    'django.middleware.common.BrokenLinkEmailsMiddleware',
+    #'django.middleware.common.BrokenLinkEmailsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -126,17 +126,6 @@ MIDDLEWARE_CLASSES = (
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 
 )
-
-# I've added in this block and commented it out.
-# we may decide we want to add some patterns in here
-# if we start getting to much email from non-critical sources.
-# import re
-# IGNORABLE_404_URLS = (
-#     re.compile(r'^/apple-touch-icon.*\.png$'),
-#     re.compile(r'^/favicon\.ico$'),
-#     re.compile(r'^/robots\.txt$'),
-# )
-
 
 AUTHENTICATION_BACKENDS = (
     'icommons_common.auth.backends.PINAuthBackend',

--- a/icommons_ext_tools/settings/production.py
+++ b/icommons_ext_tools/settings/production.py
@@ -155,17 +155,17 @@ LOGGING = {
             'propagate': True,
         },
         'qualtrics_link': {
-            'handlers': ['console', 'logfile'],
+            'handlers': ['mail_admins', 'logfile'],
             'level': 'DEBUG',
             'propagate': True,
         },
         'icommons_common': {
-            'handlers': ['mail_admins', 'console', 'logfile'],
+            'handlers': ['mail_admins', 'logfile'],
             'level': 'DEBUG',
             'propagate': True,
         },
         'canvas_course_site_wizard': {
-            'handlers': ['console', 'logfile'],
+            'handlers': ['mail_admins', 'logfile'],
             'level': 'DEBUG',
             'propagate': True,
         },

--- a/icommons_ext_tools/settings/qa.py
+++ b/icommons_ext_tools/settings/qa.py
@@ -158,7 +158,7 @@ LOGGING = {
             'propagate': True,
         },
         'qualtrics_link': {
-            'handlers': ['console', 'logfile'],
+            'handlers': ['mail_admins', 'logfile'],
             'level': 'DEBUG',
             'propagate': True,
         },
@@ -168,7 +168,7 @@ LOGGING = {
             'propagate': True,
         },
         'canvas_course_site_wizard': {
-            'handlers': ['console', 'logfile'],
+            'handlers': ['mail_admins', 'logfile'],
             'level': 'DEBUG',
             'propagate': True,
         },


### PR DESCRIPTION
minor settings changes to allow admin email to be sent. Added 'mail-admins' to logger settings, enabled EMAIL_USE_TLS = True. 
