### PR TITLE
Updates general error page text and course site wizard error page text

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -74,13 +74,17 @@
       <ul>
         <li>DCE: <a href="mailto:AcademicTechnology@dce.harvard.edu{% if renderable_error %}?subject={{ renderable_error.display_text }}{% endif %}">AcademicTechnology@dce.harvard.edu</a></li>
         <li>FAS: <a href="mailto:atg@fas.harvard.edu{% if renderable_error %}?subject={{ renderable_error.display_text }}{% endif %}">atg@fas.harvard.edu</a></li>
-        <li>GSD: <a href="mailto:klau@gsd.harvard.edu{% if renderable_error %}?subject={{ renderable_error.display_text }}{% endif %}">klau@gsd.harvard.edu</a></li>
-        <li>GSE: <a href="mailto:it_onestop@gse.harvard.edu{% if renderable_error %}?subject={{ renderable_error.display_text }}{% endif %}">it_onestop@gse.harvard.edu</a></li>
-        <li>HDS: <a href="mailto:coursesites@hds.harvard.edu{% if renderable_error %}?subject={{ renderable_error.display_text }}{% endif %}">coursesites@hds.harvard.edu</a></li>
-        <li>HKS: <a href="mailto:helpdesk@hks.harvard.edu{% if renderable_error %}?subject={{ renderable_error.display_text }}{% endif %}">helpdesk@hks.harvard.edu</a></li>
-        <li>HLS: <a href="mailto:ask@edtech.libanswers.com{% if renderable_error %}?subject={{ renderable_error.display_text }}{% endif %}">ask@edtech.libanswers.com</a></li>
-        <li>HMS: <a href="mailto:mycourses_support@hms.harvard.edu{% if renderable_error %}?subject={{ renderable_error.display_text }}{% endif %}">mycourses_support@hms.harvard.edu</a></li>
-        <li>HSPH: <a href="mailto:icf@hsph.harvard.edu{% if renderable_error %}?subject={{ renderable_error.display_text }}{% endif %}">icf@hsph.harvard.edu</a></li>
+        {# Note: For icommons_ext_tools, renderable_errors are currently only being shown by django_canvas_course_site_wizard #}
+        {# TLT-486 specifies that only DCE and FAS point of contact info will be shown for errors during Canvas course site creation #}
+        {% if not renderable_error %}
+          <li>GSD: <a href="mailto:klau@gsd.harvard.edu{% if renderable_error %}?subject={{ renderable_error.display_text }}{% endif %}">klau@gsd.harvard.edu</a></li>
+          <li>GSE: <a href="mailto:it_onestop@gse.harvard.edu{% if renderable_error %}?subject={{ renderable_error.display_text }}{% endif %}">it_onestop@gse.harvard.edu</a></li>
+          <li>HDS: <a href="mailto:coursesites@hds.harvard.edu{% if renderable_error %}?subject={{ renderable_error.display_text }}{% endif %}">coursesites@hds.harvard.edu</a></li>
+          <li>HKS: <a href="mailto:helpdesk@hks.harvard.edu{% if renderable_error %}?subject={{ renderable_error.display_text }}{% endif %}">helpdesk@hks.harvard.edu</a></li>
+          <li>HLS: <a href="mailto:ask@edtech.libanswers.com{% if renderable_error %}?subject={{ renderable_error.display_text }}{% endif %}">ask@edtech.libanswers.com</a></li>
+          <li>HMS: <a href="mailto:mycourses_support@hms.harvard.edu{% if renderable_error %}?subject={{ renderable_error.display_text }}{% endif %}">mycourses_support@hms.harvard.edu</a></li>
+          <li>HSPH: <a href="mailto:mets@hsph.harvard.edu{% if renderable_error %}?subject={{ renderable_error.display_text }}{% endif %}">mets@hsph.harvard.edu</a></li>
+        {% endif %}
       </ul>
     {% endif %}
 


### PR DESCRIPTION
- updates email for HSPH on general error pages
- only shows DCE and FAS point of contact emails now for course site wizard errors
