### PR TITLE
Feature/move common settings to base and add a few new settings

### DIFF
--- a/canvas_wizard/canvas_api.py
+++ b/canvas_wizard/canvas_api.py
@@ -19,7 +19,7 @@ pp = pprint.PrettyPrinter(indent=4)
 
 AUTH_TOKEN = 'Bearer %s' % settings.CANVAS_WIZARD.get('TOKEN')
 HEADERS = {'Authorization ': AUTH_TOKEN}
-CANVAS_SERVER_BASE_URL = settings.CANVAS_WIZARD.get('CANVAS_SERVER_BASE_URL')
+CANVAS_SERVER_BASE_URL = settings.CANVAS_URL
 
 
 class Canvasapi(object):

--- a/icommons_ext_tools/settings/base.py
+++ b/icommons_ext_tools/settings/base.py
@@ -67,8 +67,7 @@ EMAIL_FILE_PATH = LOG_ROOT
 
 # Use smtp.EmailBackend with EMAIL_HOST and EMAIL_USE_TLS
 # to send actual mail via SMTP
-# Note that if DEBUG = True (because these are the integration test settings),
-# emails will not be sent by the ADMINS email handler
+# Note that if DEBUG = True, emails will not be sent by the ADMINS email handler
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST = SECURE_SETTINGS.get('email_host', 'mailhost.harvard.edu')
 EMAIL_HOST_USER = SECURE_SETTINGS.get('email_host_user', '')
@@ -261,11 +260,11 @@ ICOMMONS_COMMON = {
 CANVAS_URL = SECURE_SETTINGS['canvas_url']
 
 COURSE_WIZARD = {
-    'OLD_LMS_URL' : SECURE_SETTINGS.get('old_lms_url', None),
+    'OLD_LMS_URL': SECURE_SETTINGS.get('old_lms_url', None),
 }
 
 CANVAS_WIZARD = {
-    'TOKEN' : SECURE_SETTINGS['canvas_token'],
+    'TOKEN': SECURE_SETTINGS['canvas_token'],  # Need a token
 }
 
 CANVAS_SITE_SETTINGS = {

--- a/icommons_ext_tools/settings/base.py
+++ b/icommons_ext_tools/settings/base.py
@@ -30,14 +30,22 @@ path.append(SITE_ROOT)
 ### End path stuff
 
 # THESE ADDRESSES WILL RECEIVE EMAIL ABOUT CERTAIN ERRORS!
-ADMINS = SECURE_SETTINGS.get('admins')
+# Note: If this list (technically a tuple) has only one element, that
+#       element must be followed by a comma for it to be processed
+#       (cf section 3.2 of https://docs.python.org/2/reference/datamodel.html)
+ADMINS = (
+    ('iCommons Tech', 'icommons-technical@g.harvard.edu'),
+),
+
+# LOG_ROOT used for log file storage; EMAIL_FILE_PATH used for
+# email output if EMAIL_BACKEND is filebased.EmailBackend
+LOG_ROOT = SECURE_SETTINGS.get('log_root', 'logs/')
 
 # This is the address that admin emails (sent to the addresses in the ADMINS list) will be sent 'from'.
 # It can be overridden in specific settings files to indicate what environment
 # is producing admin emails (e.g. 'app env <email>').
-SERVER_EMAIL_DISPLAY_NAME = '%s - %s' % (DJANGO_PROJECT_CONFIG, get_settings_file_name(__file__))
-SERVER_EMAIL_EMAIL_ADDR = 'icommons-bounces@harvard.edu'
-SERVER_EMAIL = '%s <%s>' % (SERVER_EMAIL_DISPLAY_NAME, SERVER_EMAIL_EMAIL_ADDR)
+SERVER_EMAIL_DISPLAY_NAME = '%s - %s' % (DJANGO_PROJECT_CONFIG, SECURE_SETTINGS.get('env_name', 'production'))
+SERVER_EMAIL = '%s <%s>' % (SERVER_EMAIL_DISPLAY_NAME, 'icommons-bounces@harvard.edu')
 
 # Email subject prefix is what's shown at the beginning of the ADMINS email subject line
 # Django's default is "[Django] ", which isn't helpful and wastes space in the subject line
@@ -55,13 +63,20 @@ EMAIL_SUBJECT_PREFIX = ''
 # environment settings files to point to the environment-specific log directory.
 # Here in the base settings it's set explicitly to None so it will throw an
 # Exception unless overridden in individual environment settings
-EMAIL_FILE_PATH = None
+EMAIL_FILE_PATH = LOG_ROOT
+
 # Use smtp.EmailBackend with EMAIL_HOST and EMAIL_USE_TLS
 # to send actual mail via SMTP
+# Note that if DEBUG = True (because these are the integration test settings),
+# emails will not be sent by the ADMINS email handler
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
-EMAIL_HOST = 'mailhost.harvard.edu'
-EMAIL_USE_TLS = False
-EMAIL_PORT = 25
+EMAIL_HOST = SECURE_SETTINGS.get('email_host', 'mailhost.harvard.edu')
+EMAIL_HOST_USER = SECURE_SETTINGS.get('email_host_user', '')
+EMAIL_HOST_PASSWORD = SECURE_SETTINGS.get('email_host_password', '')
+EMAIL_USE_TLS = SECURE_SETTINGS.get('email_use_tls', False)
+# EMAIL_PORT for use in AWS environment
+# (see http://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-connect.html)
+EMAIL_PORT = SECURE_SETTINGS.get('email_port', 25)
 
 MANAGERS = ADMINS
 
@@ -235,3 +250,42 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 CRISPY_TEMPLATE_PACK = 'bootstrap3'
 
 LOGIN_URL = reverse_lazy('pin:login')
+
+ICOMMONS_COMMON = {
+    'ICOMMONS_API_HOST': SECURE_SETTINGS.get('icommons_api_host', None),
+    'ICOMMONS_API_USER': SECURE_SETTINGS.get('icommons_api_user', None),
+    'ICOMMONS_API_PASS': SECURE_SETTINGS.get('icommons_api_pass', None),
+}
+
+# Important this be declared, so let it throw a key error if not found
+CANVAS_URL = SECURE_SETTINGS['canvas_url']
+
+COURSE_WIZARD = {
+    'OLD_LMS_URL' : SECURE_SETTINGS.get('old_lms_url', None),
+}
+
+CANVAS_WIZARD = {
+    'TOKEN' : SECURE_SETTINGS['canvas_token'],
+}
+
+CANVAS_SITE_SETTINGS = {
+    'base_url': CANVAS_URL + '/',
+}
+
+CANVAS_SDK_SETTINGS = {
+    'auth_token': SECURE_SETTINGS['canvas_token'],  # Need a token
+    'base_api_url': CANVAS_URL + '/api',
+    'max_retries': 3,
+    'per_page': 1000,
+}
+
+QUALTRICS_LINK = {
+    'AGREEMENT_ID' : SECURE_SETTINGS.get('qualtrics_agreement_id', None),
+    'QUALTRICS_APP_KEY' : SECURE_SETTINGS.get('qualtrics_app_key', None),
+    'QUALTRICS_API_URL' : SECURE_SETTINGS.get('qualtrics_api_url', None),
+    'QUALTRICS_API_USER' : SECURE_SETTINGS.get('qualtrics_api_user', None),
+    'QUALTRICS_API_TOKEN' : SECURE_SETTINGS.get('qualtrics_api_token', None),
+    'QUALTRICS_AUTH_GROUP' : SECURE_SETTINGS.get('qualtrics_auth_group', None),
+    'USER_DECLINED_TERMS_URL': 'ql:internal',
+    'USER_ACCEPTED_TERMS_URL': 'ql:internal',
+}

--- a/icommons_ext_tools/settings/demo.py
+++ b/icommons_ext_tools/settings/demo.py
@@ -2,5 +2,5 @@
 from .qa import *
 
 # sets 'from' email to show project and settings file name when sending emails to ADMINS
-SERVER_EMAIL_DISPLAY_NAME = '%s - %s' % (PROJECT_NAME, get_settings_file_name(__file__))
-SERVER_EMAIL = '%s <%s>' % (SERVER_EMAIL_DISPLAY_NAME, SERVER_EMAIL_EMAIL_ADDR)
+# SERVER_EMAIL_DISPLAY_NAME = '%s - %s' % (PROJECT_NAME, get_settings_file_name(__file__))
+# SERVER_EMAIL = '%s <%s>' % (SERVER_EMAIL_DISPLAY_NAME, SERVER_EMAIL_EMAIL_ADDR)

--- a/icommons_ext_tools/settings/local.py
+++ b/icommons_ext_tools/settings/local.py
@@ -1,5 +1,4 @@
 from .base import *
-from .secure import SECURE_SETTINGS
 
 # To allow local development server to load static files with DEBUG=False, run:
 #   manage.py runserver --insecure
@@ -10,60 +9,14 @@ CRISPY_FAIL_SILENTLY = not DEBUG
 
 # LOG_ROOT used for log file storage; EMAIL_FILE_PATH used for
 # email output if EMAIL_BACKEND is filebased.EmailBackend
-LOG_ROOT = join(SITE_ROOT, 'logs/')
-EMAIL_FILE_PATH = LOG_ROOT
-
-# sets 'from' email to show project and settings file name when sending emails to ADMINS
-SERVER_EMAIL_DISPLAY_NAME = '%s - %s' % (PROJECT_NAME, get_settings_file_name(__file__))
-SERVER_EMAIL = '%s <%s>' % (SERVER_EMAIL_DISPLAY_NAME, SERVER_EMAIL_EMAIL_ADDR)
-
-ICOMMONS_COMMON = {
-
-    'ICOMMONS_API_HOST': 'https://qa.isites.harvard.edu/services/',
-    'ICOMMONS_API_USER': SECURE_SETTINGS['icommons_api_user'],
-    'ICOMMONS_API_PASS': SECURE_SETTINGS['icommons_api_pass'],
-}
 
 ISITES_LMS_URL = 'http://isites.harvard.edu/'
 
-CANVAS_WIZARD = {
-    'TOKEN' : SECURE_SETTINGS['TOKEN'],
-}
-
-COURSE_WIZARD = {
-    'OLD_LMS_URL' : SECURE_SETTINGS['OLD_LMS_URL'],
-}
-
-QUALTRICS_LINK = {
-
-    'AGREEMENT_ID' : SECURE_SETTINGS['qualtrics_agreement_id'],
-    'QUALTRICS_APP_KEY' : SECURE_SETTINGS['qualtrics_app_key'],
-    'QUALTRICS_API_URL' : SECURE_SETTINGS['qualtrics_api_url'],
-    'QUALTRICS_API_USER' : SECURE_SETTINGS['qualtrics_api_user'],
-    'QUALTRICS_API_TOKEN' : SECURE_SETTINGS['qualtrics_api_token'],
-    'QUALTRICS_AUTH_GROUP' : SECURE_SETTINGS['qualtrics_auth_group'],
-    #'USER_DECLINED_TERMS_URL' : 'http://surveytools.harvard.edu',
-    'USER_DECLINED_TERMS_URL' : 'ql:internal', # only in QA
-    'USER_ACCEPTED_TERMS_URL' : 'ql:internal', # only in QA
-}
-
-CANVAS_SITE_SETTINGS = {
-    'base_url': 'https://canvas.icommons.harvard.edu/',
-
-}
 
 CANVAS_EMAIL_NOTIFICATION['course_migration_success_subject'] += ' (TEST, PLEASE IGNORE)'
 CANVAS_EMAIL_NOTIFICATION['course_migration_failure_subject'] += ' (TEST, PLEASE IGNORE)'
 CANVAS_EMAIL_NOTIFICATION['support_email_subject_on_failure'] += ' (TEST, PLEASE IGNORE)'
 CANVAS_EMAIL_NOTIFICATION['environment'] = 'Local'
-
-
-CANVAS_SDK_SETTINGS = {
-    'auth_token': SECURE_SETTINGS.get('canvas_token', None),
-    'base_api_url': CANVAS_SITE_SETTINGS['base_url'] + 'api',
-    'max_retries': 3,
-    'per_page': 40,
-}
 
 DATABASES = {
 
@@ -113,8 +66,6 @@ DATABASE_EXTRAS = {
     'threaded': True,
 }
 '''
-
-STATIC_ROOT = normpath(join(SITE_ROOT, 'http_static'))
 
 INSTALLED_APPS += (
     'debug_toolbar',

--- a/icommons_ext_tools/settings/production.py
+++ b/icommons_ext_tools/settings/production.py
@@ -9,48 +9,9 @@ DEBUG = False
 
 ALLOWED_HOSTS = ['*']
 
-# LOG_ROOT used for log file storage; EMAIL_FILE_PATH used for
-# email output if EMAIL_BACKEND is filebased.EmailBackend
-LOG_ROOT = join(SITE_ROOT, '/logs/icommons_ext_tools/')
-EMAIL_FILE_PATH = LOG_ROOT
-
-# sets 'from' email to show project and settings file name when sending emails to ADMINS
-SERVER_EMAIL_DISPLAY_NAME = '%s - %s' % (PROJECT_NAME, get_settings_file_name(__file__))
-SERVER_EMAIL = '%s <%s>' % (SERVER_EMAIL_DISPLAY_NAME, SERVER_EMAIL_EMAIL_ADDR)
-
-ICOMMONS_COMMON = {
-    'ICOMMONS_API_HOST': 'https://isites.harvard.edu/services/',
-    'ICOMMONS_API_USER': SECURE_SETTINGS.get('icommons_api_user'),
-    'ICOMMONS_API_PASS': SECURE_SETTINGS.get('icommons_api_pass'),
-}
-
-QUALTRICS_LINK = {
-    'AGREEMENT_ID' : SECURE_SETTINGS.get('qualtrics_agreement_id'),
-    'QUALTRICS_APP_KEY' : SECURE_SETTINGS.get('qualtrics_app_key'),
-    'QUALTRICS_API_URL' : SECURE_SETTINGS.get('qualtrics_api_url'),
-    'QUALTRICS_API_USER' : SECURE_SETTINGS.get('qualtrics_api_user'),
-    'QUALTRICS_API_TOKEN' : SECURE_SETTINGS.get('qualtrics_api_token'),
-    'QUALTRICS_AUTH_GROUP' : SECURE_SETTINGS.get('qualtrics_auth_group'),
-    'USER_DECLINED_TERMS_URL' : 'http://surveytools.harvard.edu',
-    'USER_ACCEPTED_TERMS_URL' : 'ql:launch',
-}
-
-CANVAS_SITE_SETTINGS = {
-    'base_url': 'https://canvas.harvard.edu/',
-}
-
-
-CANVAS_SDK_SETTINGS = {
-    'auth_token': SECURE_SETTINGS.get('canvas_token', None),
-    'base_api_url': CANVAS_SITE_SETTINGS['base_url'] + 'api',
-    'max_retries': 3,
-    'per_page': 1000,
-}
-
-CANVAS_WIZARD = {
-    'TOKEN' : SECURE_SETTINGS.get('TOKEN', 'changeme'),
-}
-
+# Update qualtrics term urls in prod
+QUALTRICS_LINK['USER_DECLINED_TERMS_URL'] = 'http://surveytools.harvard.edu'
+QUALTRICS_LINK['USER_ACCEPTED_TERMS_URL'] = 'ql:launch'
 
 ISITES_LMS_URL = 'http://isites.harvard.edu/'
 
@@ -84,8 +45,6 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
     }
 }
-
-EMAIL_HOST = SECURE_SETTINGS.get('EMAIL_HOST')
 
 #CACHES = {
 #    'default': {

--- a/icommons_ext_tools/settings/qa.py
+++ b/icommons_ext_tools/settings/qa.py
@@ -5,60 +5,12 @@ DEBUG = False
 
 ALLOWED_HOSTS = ['*']
 
-# LOG_ROOT used for log file storage; EMAIL_FILE_PATH used for
-# email output if EMAIL_BACKEND is filebased.EmailBackend
-LOG_ROOT = '/var/opt/tlt/logs/'
-EMAIL_FILE_PATH = LOG_ROOT
-
-# sets 'from' email to show project and settings file name when sending emails to ADMINS
-SERVER_EMAIL_DISPLAY_NAME = '%s - %s' % (PROJECT_NAME, get_settings_file_name(__file__))
-SERVER_EMAIL = '%s <%s>' % (SERVER_EMAIL_DISPLAY_NAME, SERVER_EMAIL_EMAIL_ADDR)
-
-ICOMMONS_COMMON = {
-    'ICOMMONS_API_HOST': 'https://10.35.201.5/services/',
-    'ICOMMONS_API_USER': SECURE_SETTINGS.get('icommons_api_user', None),
-    'ICOMMONS_API_PASS': SECURE_SETTINGS.get('icommons_api_pass', None),
-}
-
-CANVAS_WIZARD = {
-    'TOKEN' : SECURE_SETTINGS.get('TOKEN', 'changeme'),
-}
-
 ISITES_LMS_URL = 'http://qa.isites.harvard.edu/'
-
-COURSE_WIZARD = {
-    'OLD_LMS_URL' : SECURE_SETTINGS.get('OLD_LMS_URL', None),
-}
-
-QUALTRICS_LINK = {
-    'AGREEMENT_ID' : SECURE_SETTINGS.get('qualtrics_agreement_id', None),
-    'QUALTRICS_APP_KEY' : SECURE_SETTINGS.get('qualtrics_app_key', None),
-    'QUALTRICS_API_URL' : SECURE_SETTINGS.get('qualtrics_api_url', None),
-    'QUALTRICS_API_USER' : SECURE_SETTINGS.get('qualtrics_api_user', None),
-    'QUALTRICS_API_TOKEN' : SECURE_SETTINGS.get('qualtrics_api_token', None),
-    'QUALTRICS_AUTH_GROUP' : SECURE_SETTINGS.get('qualtrics_auth_group', None),
-    'USER_DECLINED_TERMS_URL' : 'ql:internal', # only in QA
-    'USER_ACCEPTED_TERMS_URL' : 'ql:internal', # only in QA
-}
-
-CANVAS_SITE_SETTINGS = {
-    'base_url' : 'https://canvas.icommons.harvard.edu/',
-    #'base_url' : 'https://harvard.beta.instructure.com/',
-}
 
 CANVAS_EMAIL_NOTIFICATION['course_migration_success_subject'] += ' (TEST, PLEASE IGNORE)'
 CANVAS_EMAIL_NOTIFICATION['course_migration_failure_subject'] += ' (TEST, PLEASE IGNORE)'
 CANVAS_EMAIL_NOTIFICATION['support_email_subject_on_failure'] += ' (TEST, PLEASE IGNORE)'
 CANVAS_EMAIL_NOTIFICATION['environment'] = 'QA'
-
-
-
-CANVAS_SDK_SETTINGS = {
-    'auth_token': SECURE_SETTINGS.get('canvas_token', None),
-    'base_api_url': CANVAS_SITE_SETTINGS['base_url'] + 'api',
-    'max_retries': 3,
-    'per_page': 1000,
-}
 
 DATABASES = {
     'default': {
@@ -90,29 +42,6 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
     }
 }
-
-EMAIL_HOST = SECURE_SETTINGS.get('EMAIL_HOST')
-EMAIL_HOST_USER = SECURE_SETTINGS.get('EMAIL_HOST_USER')
-EMAIL_HOST_PASSWORD = SECURE_SETTINGS.get('EMAIL_HOST_PASSWORD')
-EMAIL_USE_TLS = True
-# EMAIL_PORT for use in AWS environment
-# (see http://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-connect.html)
-EMAIL_PORT = 587
-
-#CACHES = {
-#    'default': {
-#        'BACKEND': 'redis_cache.RedisCache',
-#        'LOCATION': '127.0.0.1:6379',
-#        'OPTIONS': {
-#            'PARSER_CLASS': 'redis.connection.HiredisParser'
-#        },
-#    },
-#}
-
-#SESSION_ENGINE = 'redis_sessions.session'
-#SESSION_REDIS_HOST = 'localhost'
-#SESSION_REDIS_PORT = 6379
-#SESSION_COOKIE_SECURE = True
 
 LOGGING = {
     'version': 1,

--- a/icommons_ext_tools/settings/secure.py.j2
+++ b/icommons_ext_tools/settings/secure.py.j2
@@ -1,11 +1,15 @@
 SECURE_SETTINGS = {
+   'env_name': '{{ secure_settings.env_name }}',
+
    'django_db_user': '{{ secure_settings.django_db_user }}',
    'django_db_pass': '{{ secure_settings.django_db_pass }}',
    'django_secret_key': '{{ secure_settings.django_secret_key }}',
 
+   'icommons_api_host': '{{ secure_settings.icommons_api_host }}',
    'icommons_api_user': '{{ secure_settings.icommons_api_user }}',
    'icommons_api_pass': '{{ secure_settings.icommons_api_pass }}',
 
+   'canvas_url': '{{ secure_settings.canvas_url }}',
    'canvas_token': '{{ secure_settings.canvas_token }}',
 
    'qualtrics_agreement_id': '{{ secure_settings.qualtrics_agreement_id }}',
@@ -15,16 +19,11 @@ SECURE_SETTINGS = {
    'qualtrics_api_user': '{{ secure_settings.qualtrics_api_user }}',
    'qualtrics_api_token': '{{ secure_settings.qualtrics_api_token }}',
 
-   # Note: If this list (technically a tuple) has only one element, that
-   #       element must be followed by a comma for it to be processed
-   #       (cf section 3.2 of https://docs.python.org/2/reference/datamodel.html)
-   'admins': (
-       ('iCommons Tech', 'icommons-technical@g.harvard.edu'),
-   ),
-
-   'EMAIL_HOST': '{{ secure_settings.email_host }}',
-   'EMAIL_HOST_USER': '{{ secure_settings.email_host_user }}',
-   'EMAIL_HOST_PASSWORD': '{{ secure_settings.email_host_password }}',
+   'email_host': '{{ secure_settings.email_host }}',
+   'email_host_user': '{{ secure_settings.email_host_user }}',
+   'email_host_password': '{{ secure_settings.email_host_password }}',
+   'email_port': '{{ secure_settings.email_port }}',
+   'email_use_tls': '{{ secure_settings.email_use_tls }}',
 
    # TODO: remove since not used anywhere
    'cipher_key' : '{{ secure_settings.cipher_key }}',
@@ -32,11 +31,5 @@ SECURE_SETTINGS = {
    ######
    # TODO: remove these since used in canvas_wizard non-production app
    ######
-   # should match value from canvas_token above
-   'TOKEN': '{{ secure_settings.canvas_token }}',
-
-   ######
-   # TODO: remove these since used in canvas_wizard non-production app
-   ######
-   'OLD_LMS_URL' : '{{ secure_settings.old_lms_url }}',
+   'old_lms_url' : '{{ secure_settings.old_lms_url }}',
 }

--- a/icommons_ext_tools/settings/secure.py.j2
+++ b/icommons_ext_tools/settings/secure.py.j2
@@ -1,5 +1,6 @@
 SECURE_SETTINGS = {
-   'env_name': '{{ secure_settings.env_name }}',
+   'env_name': '{{ secure_settings.env_name }}',  # Name of deploy environment
+   'log_root': '{{ secure_settings.log_root }}',  # Directory where logs are stored
 
    'django_db_user': '{{ secure_settings.django_db_user }}',
    'django_db_pass': '{{ secure_settings.django_db_pass }}',
@@ -8,8 +9,7 @@ SECURE_SETTINGS = {
    'icommons_api_host': '{{ secure_settings.icommons_api_host }}',
    'icommons_api_user': '{{ secure_settings.icommons_api_user }}',
    'icommons_api_pass': '{{ secure_settings.icommons_api_pass }}',
-
-   'canvas_url': '{{ secure_settings.canvas_url }}',
+   'canvas_url': '{{ secure_settings.canvas_url }}',  # Base url of Canvas instance
    'canvas_token': '{{ secure_settings.canvas_token }}',
 
    'qualtrics_agreement_id': '{{ secure_settings.qualtrics_agreement_id }}',

--- a/icommons_ext_tools/settings/test.py
+++ b/icommons_ext_tools/settings/test.py
@@ -7,67 +7,12 @@ DEBUG = True
 
 ALLOWED_HOSTS = ['*']
 
-# LOG_ROOT used for log file storage; EMAIL_FILE_PATH used for
-# email output if EMAIL_BACKEND is filebased.EmailBackend
-LOG_ROOT = '/var/opt/tlt/logs/'
-EMAIL_FILE_PATH = LOG_ROOT
-
-# sets 'from' email to show project and settings file name when sending emails to ADMINS
-SERVER_EMAIL_DISPLAY_NAME = '%s - %s' % (PROJECT_NAME, get_settings_file_name(__file__))
-SERVER_EMAIL = '%s <%s>' % (SERVER_EMAIL_DISPLAY_NAME, SERVER_EMAIL_EMAIL_ADDR)
-
-# Note that if DEBUG = True (because these are the integration test settings),
-# emails will not be sent by the ADMINS email handler
-EMAIL_HOST = SECURE_SETTINGS.get('EMAIL_HOST')
-EMAIL_HOST_USER = SECURE_SETTINGS.get('EMAIL_HOST_USER')
-EMAIL_HOST_PASSWORD = SECURE_SETTINGS.get('EMAIL_HOST_PASSWORD')
-EMAIL_USE_TLS = True
-# EMAIL_PORT for use in AWS environment
-# (see http://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-connect.html)
-EMAIL_PORT = 587
-
-ICOMMONS_COMMON = {
-    'ICOMMONS_API_HOST': 'https://isites.harvard.edu/services/',
-    'ICOMMONS_API_USER': SECURE_SETTINGS.get('icommons_api_user', None),
-    'ICOMMONS_API_PASS': SECURE_SETTINGS.get('icommons_api_pass', None),
-}
-
-CANVAS_WIZARD = {
-    'TOKEN' : SECURE_SETTINGS.get('TOKEN', 'changeme'),
-}
-
 ISITES_LMS_URL = 'http://qa.isites.harvard.edu/'
-
-COURSE_WIZARD = {
-    'OLD_LMS_URL' : SECURE_SETTINGS.get('OLD_LMS_URL', None),
-}
-
-QUALTRICS_LINK = {
-    'AGREEMENT_ID' : SECURE_SETTINGS.get('qualtrics_agreement_id', None),
-    'QUALTRICS_APP_KEY' : SECURE_SETTINGS.get('qualtrics_app_key', None),
-    'QUALTRICS_API_URL' : SECURE_SETTINGS.get('qualtrics_api_url', None),
-    'QUALTRICS_API_USER' : SECURE_SETTINGS.get('qualtrics_api_user', None),
-    'QUALTRICS_API_TOKEN' : SECURE_SETTINGS.get('qualtrics_api_token', None),
-    'QUALTRICS_AUTH_GROUP' : SECURE_SETTINGS.get('qualtrics_auth_group', None),
-    'USER_DECLINED_TERMS_URL' : 'ql:internal', # only in QA
-    'USER_ACCEPTED_TERMS_URL' : 'ql:internal', # only in QA
-}
-
-CANVAS_SITE_SETTINGS = {
-    'base_url': 'https://canvas.icommons.harvard.edu/',
-}
 
 CANVAS_EMAIL_NOTIFICATION['course_migration_success_subject'] += ' (TEST, PLEASE IGNORE)'
 CANVAS_EMAIL_NOTIFICATION['course_migration_failure_subject'] += ' (TEST, PLEASE IGNORE)'
 CANVAS_EMAIL_NOTIFICATION['support_email_subject_on_failure'] += ' (TEST, PLEASE IGNORE)'
 CANVAS_EMAIL_NOTIFICATION['environment'] = 'Test'
-
-CANVAS_SDK_SETTINGS = {
-    'auth_token': SECURE_SETTINGS.get('canvas_token', None),
-    'base_api_url': CANVAS_SITE_SETTINGS['base_url'] + 'api',
-    'max_retries': 3,
-    'per_page': 40,
-}
 
 DATABASES = {
     'default': {
@@ -101,8 +46,6 @@ DATABASE_EXTRAS = {
     'threaded': True,
 }
 '''
-
-STATIC_ROOT = normpath(join(SITE_ROOT, 'http_static'))
 
 INSTALLED_APPS += (
     #'debug_toolbar',
@@ -247,5 +190,3 @@ The school must be the same as the school_id in the school model.
 
 
 GUNICORN_CONFIG = 'gunicorn_test.py'
-
-

--- a/icommons_ext_tools/settings/test_settings.py
+++ b/icommons_ext_tools/settings/test_settings.py
@@ -1,9 +1,5 @@
 from .base import *
 
-# sets 'from' email to show project and settings file name when sending emails to ADMINS
-SERVER_EMAIL_DISPLAY_NAME = '%s - %s' % (PROJECT_NAME, get_settings_file_name(__file__))
-SERVER_EMAIL = '%s <%s>' % (SERVER_EMAIL_DISPLAY_NAME, SERVER_EMAIL_EMAIL_ADDR)
-
 # ensures mail won't be sent by unit tests
 ADMINS = ()
 MANAGERS = ADMINS
@@ -20,29 +16,6 @@ DATABASES = {
 
 ISITES_LMS_URL = ''
 
-ICOMMONS_COMMON = {
-
-    'ICOMMONS_API_HOST': 'https://qa.isites.harvard.edu/services/',
-    'ICOMMONS_API_USER': SECURE_SETTINGS['icommons_api_user'],
-    'ICOMMONS_API_PASS': SECURE_SETTINGS['icommons_api_pass'],
-    'HARVARD_ACCOUNT_ID':'1',
-}
-
-
-ICOMMONS_COMMON = {
-    'ICOMMONS_API_HOST': 'https://isites.harvard.edu/services/',
-    'ICOMMONS_API_USER': SECURE_SETTINGS.get('icommons_api_user', None),
-    'ICOMMONS_API_PASS': SECURE_SETTINGS.get('icommons_api_pass', None),
-}
-
-CANVAS_WIZARD = {
-    'TOKEN' : SECURE_SETTINGS.get('TOKEN', 'changeme'),
-}
-
-COURSE_WIZARD = {
-    'OLD_LMS_URL' : SECURE_SETTINGS.get('OLD_LMS_URL', None),
-}
-
 QUALTRICS_LINK = {
     'AGREEMENT_ID' : SECURE_SETTINGS.get('qualtrics_agreement_id', None),
     'QUALTRICS_APP_KEY' : SECURE_SETTINGS.get('qualtrics_app_key', None),
@@ -54,16 +27,6 @@ QUALTRICS_LINK = {
     'USER_ACCEPTED_TERMS_URL' : 'ql:internal', # only in QA
 }
 
-CANVAS_SITE_SETTINGS = {
-    'base_url': 'https://canvas.icommons.harvard.edu/',
-}
-
-CANVAS_SDK_SETTINGS = {
-    'auth_token': SECURE_SETTINGS.get('canvas_token', None),
-    'base_api_url': CANVAS_SITE_SETTINGS['base_url'] + 'api',
-    'max_retries': 3,
-    'per_page': 40,
-}
 CANVAS_EMAIL_NOTIFICATION = {
     'from_email_address'    : 'icommons-bounces@harvard.edu',
     'support_email_address' : 'tlt_support@harvard.edu',


### PR DESCRIPTION
Move common settings to base.py. Introduce several new "secure" (really environment based) settings to help this, including:

canvas_url -> the base url of the canvas instance for the current environment,
log_root -> the relative or absolute path to where logs should be stored on the server,
icommons_api_host -> the base url of the commons api instance being used for the environment,
email_use_tls -> should we be enabling TLS in this environment?,
email_port,
env_name -> the current environment name (e.g., demo, qa),
Update secure.py.j2 with new keys.  Update an obsolete reference in the old canvas_wizard tool that was pointing to a nonexistent key.