### PR TITLE
Part of this PR addresses unit tests not being able to run in Jenkins du...

### DIFF
--- a/canvas_wizard/tests.py
+++ b/canvas_wizard/tests.py
@@ -5,6 +5,7 @@ unittest). These will both pass when you run "manage.py test".
 Replace these with more appropriate tests for your application.
 """
 
+from unittest import skip
 from django.contrib.auth.models import User
 #from icommons_common.models import School, CourseInstance, Template, TemplateAccessList, TemplateUsers, TemplateAccount, TemplateCourseDelegates
 from django.test import TestCase, RequestFactory
@@ -15,6 +16,7 @@ from .views import launch
 #import mock
 # Create your tests here.
 
+@skip("Can't test since unmanaged models cannot be instantiated")
 class SimpleTest(TestCase):
     def setUp(self):
         # Every test needs access to the request factory.

--- a/icommons_ext_tools/requirements/base.txt
+++ b/icommons_ext_tools/requirements/base.txt
@@ -11,7 +11,6 @@ wsgiref==0.1.2
 python-gnupg==0.3.5
 pycrypto==2.6.1
 bitly_api==0.3
-huey==0.4.1
 djangorestframework==2.3.9
 django-supervisor==0.3.2
 
@@ -24,4 +23,7 @@ django-redis-sessions==0.4.0
 
 django-cached-authentication-middleware>=0.2.0
 
+git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.7b5#egg=canvas-python-sdk
+
 dj-static
+mock

--- a/icommons_ext_tools/requirements/demo.txt
+++ b/icommons_ext_tools/requirements/demo.txt
@@ -9,7 +9,6 @@ newrelic==2.8.0.7
 gunicorn
 
 # Note: In the demo environment we use the /master branch
-git+ssh://git@github.com/penzance/canvas_python_sdk.git@master#egg=canvas-python-sdk
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@master#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@master#egg=django-icommons-ui
 git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@master#egg=django-canvas-course-site-wizard

--- a/icommons_ext_tools/requirements/local.txt
+++ b/icommons_ext_tools/requirements/local.txt
@@ -22,5 +22,4 @@ git+https://github.com/inducer/pudb.git#egg=pudb
 # Remote repositories
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@develop#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@develop#egg=django-icommons-ui
-git+ssh://git@github.com/penzance/canvas_python_sdk.git@develop#egg=canvas-python-sdk
 git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@develop#egg=django-canvas-course-site-wizard

--- a/icommons_ext_tools/requirements/production.txt
+++ b/icommons_ext_tools/requirements/production.txt
@@ -8,7 +8,6 @@ newrelic==2.8.0.7
 
 gunicorn
 
-git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.7b5#egg=canvas-python-sdk
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.6#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.8.3#egg=django-icommons-ui
 git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v1.2.1#egg=django-canvas-course-site-wizard

--- a/icommons_ext_tools/requirements/qa.txt
+++ b/icommons_ext_tools/requirements/qa.txt
@@ -13,7 +13,6 @@ gunicorn
 #       Projects without /release branches may need to have them created an this QA settings file updated to
 #       point to /release for that project (/release branches should be created from /master and anything
 #       that needs testing should be merged into /release from /develop so it is ready for acceptance testing)
-git+ssh://git@github.com/penzance/canvas_python_sdk.git@master#egg=canvas-python-sdk
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@master#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@release#egg=django-icommons-ui
 git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@release#egg=django-canvas-course-site-wizard

--- a/icommons_ext_tools/requirements/test.txt
+++ b/icommons_ext_tools/requirements/test.txt
@@ -5,12 +5,10 @@
  
 # below are requirements specific to the test environment
 newrelic==2.8.0.7
-mock==1.0.1
 django-debug-toolbar==1.0.1
 
 git+https://github.com/inducer/pudb.git#egg=pudb
 
-git+ssh://git@github.com/penzance/canvas_python_sdk.git@develop#egg=canvas-python-sdk
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@develop#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@develop#egg=django-icommons-ui
 git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@develop#egg=django-canvas-course-site-wizard

--- a/icommons_ext_tools/settings/base.py
+++ b/icommons_ext_tools/settings/base.py
@@ -35,7 +35,7 @@ path.append(SITE_ROOT)
 #       (cf section 3.2 of https://docs.python.org/2/reference/datamodel.html)
 ADMINS = (
     ('iCommons Tech', 'icommons-technical@g.harvard.edu'),
-),
+)
 
 # LOG_ROOT used for log file storage; EMAIL_FILE_PATH used for
 # email output if EMAIL_BACKEND is filebased.EmailBackend
@@ -191,41 +191,17 @@ TEMPLATE_DIRS = (
     # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
     # Always use forward slashes, even on Windows.
     # Don't forget to use absolute paths, not relative paths.
-    SITE_ROOT + '/templates/',
+    normpath(join(SITE_ROOT, 'templates')),
 )
-
-CANVAS_EMAIL_NOTIFICATION = {
-    'from_email_address'    : 'icommons-bounces@harvard.edu',
-    'support_email_address' : 'tlt_support@harvard.edu',
-    'course_migration_success_subject'  : 'Course site is ready',
-    'course_migration_success_body'     : 'Success! \nYour new Canvas course site has been created and is ready for you at:\n'+
-            ' {0} \n\n Here are some resources for getting started with your site:\n http://tlt.harvard.edu/getting-started#teachingstaff',
-
-    'course_migration_failure_subject'  : 'Course site not created',
-    'course_migration_failure_body'     : 'There was a problem creating your course site in Canvas.\n'+
-            'Your local academic support staff has been notified and will be in touch with you.\n\n'+
-            'If you have questions please contact them at:\n'+
-            ' FAS: atg@fas.harvard.edu\n'+
-            ' DCE: academictechnology@dce.harvard.edu\n'+
-            ' (Let them know that course site creation failed for sis_course_id: {0} ',
-
-    'support_email_subject_on_failure'  : 'Course site not created',
-    'support_email_body_on_failure'     : 'There was a problem creating a course site in Canvas via the wizard.\n\n'+
-            'Course site creation failed for sis_course_id: {0}\n'+
-            'User: {1}\n'+
-            '{2}\n'+
-            'Environment: {3}\n',
-    'environment' : 'Production',
-}
 
 INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
-    'django.contrib.sites',
+    #'django.contrib.sites',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'django.contrib.webdesign',
+    #'django.contrib.webdesign',
     # Uncomment the next line to enable the admin:
     #'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:
@@ -251,20 +227,21 @@ CRISPY_TEMPLATE_PACK = 'bootstrap3'
 LOGIN_URL = reverse_lazy('pin:login')
 
 ICOMMONS_COMMON = {
-    'ICOMMONS_API_HOST': SECURE_SETTINGS.get('icommons_api_host', None),
-    'ICOMMONS_API_USER': SECURE_SETTINGS.get('icommons_api_user', None),
-    'ICOMMONS_API_PASS': SECURE_SETTINGS.get('icommons_api_pass', None),
+    'ICOMMONS_API_HOST': SECURE_SETTINGS.get('icommons_api_host'),
+    'ICOMMONS_API_USER': SECURE_SETTINGS.get('icommons_api_user'),
+    'ICOMMONS_API_PASS': SECURE_SETTINGS.get('icommons_api_pass'),
 }
 
-# Important this be declared, so let it throw a key error if not found
-CANVAS_URL = SECURE_SETTINGS['canvas_url']
+# Important this be declared, but we need to allow for unit tests to run in a Jenkins environment so
+# default to a bogus url.
+CANVAS_URL = SECURE_SETTINGS.get('canvas_url', 'https://changeme')
 
 COURSE_WIZARD = {
-    'OLD_LMS_URL': SECURE_SETTINGS.get('old_lms_url', None),
+    'OLD_LMS_URL': SECURE_SETTINGS.get('old_lms_url'),
 }
 
 CANVAS_WIZARD = {
-    'TOKEN': SECURE_SETTINGS['canvas_token'],  # Need a token
+    'TOKEN': SECURE_SETTINGS.get('canvas_token'),  # Need a token
 }
 
 CANVAS_SITE_SETTINGS = {
@@ -272,19 +249,43 @@ CANVAS_SITE_SETTINGS = {
 }
 
 CANVAS_SDK_SETTINGS = {
-    'auth_token': SECURE_SETTINGS['canvas_token'],  # Need a token
+    'auth_token': SECURE_SETTINGS.get('canvas_token'),  # Need a token
     'base_api_url': CANVAS_URL + '/api',
     'max_retries': 3,
     'per_page': 1000,
 }
 
+CANVAS_EMAIL_NOTIFICATION = {
+    'from_email_address': 'icommons-bounces@harvard.edu',
+    'support_email_address': 'tlt_support@harvard.edu',
+    'course_migration_success_subject': 'Course site is ready',
+    'course_migration_success_body': 'Success! \nYour new Canvas course site has been created and is ready for you at:\n'+
+            ' {0} \n\n Here are some resources for getting started with your site:\n http://tlt.harvard.edu/getting-started#teachingstaff',
+
+    'course_migration_failure_subject': 'Course site not created',
+    'course_migration_failure_body': 'There was a problem creating your course site in Canvas.\n'+
+            'Your local academic support staff has been notified and will be in touch with you.\n\n'+
+            'If you have questions please contact them at:\n'+
+            ' FAS: atg@fas.harvard.edu\n'+
+            ' DCE: academictechnology@dce.harvard.edu\n'+
+            ' (Let them know that course site creation failed for sis_course_id: {0} ',
+
+    'support_email_subject_on_failure': 'Course site not created',
+    'support_email_body_on_failure': 'There was a problem creating a course site in Canvas via the wizard.\n\n'+
+            'Course site creation failed for sis_course_id: {0}\n'+
+            'User: {1}\n'+
+            '{2}\n'+
+            'Environment: {3}\n',
+    'environment' : 'Production',
+}
+
 QUALTRICS_LINK = {
-    'AGREEMENT_ID' : SECURE_SETTINGS.get('qualtrics_agreement_id', None),
-    'QUALTRICS_APP_KEY' : SECURE_SETTINGS.get('qualtrics_app_key', None),
-    'QUALTRICS_API_URL' : SECURE_SETTINGS.get('qualtrics_api_url', None),
-    'QUALTRICS_API_USER' : SECURE_SETTINGS.get('qualtrics_api_user', None),
-    'QUALTRICS_API_TOKEN' : SECURE_SETTINGS.get('qualtrics_api_token', None),
-    'QUALTRICS_AUTH_GROUP' : SECURE_SETTINGS.get('qualtrics_auth_group', None),
+    'AGREEMENT_ID': SECURE_SETTINGS.get('qualtrics_agreement_id'),
+    'QUALTRICS_APP_KEY': SECURE_SETTINGS.get('qualtrics_app_key'),
+    'QUALTRICS_API_URL': SECURE_SETTINGS.get('qualtrics_api_url'),
+    'QUALTRICS_API_USER': SECURE_SETTINGS.get('qualtrics_api_user'),
+    'QUALTRICS_API_TOKEN': SECURE_SETTINGS.get('qualtrics_api_token'),
+    'QUALTRICS_AUTH_GROUP': SECURE_SETTINGS.get('qualtrics_auth_group'),
     'USER_DECLINED_TERMS_URL': 'ql:internal',
     'USER_ACCEPTED_TERMS_URL': 'ql:internal',
 }

--- a/icommons_ext_tools/settings/test_settings.py
+++ b/icommons_ext_tools/settings/test_settings.py
@@ -1,49 +1,18 @@
 from .base import *
 
-# ensures mail won't be sent by unit tests
-ADMINS = ()
-MANAGERS = ADMINS
+# NOTE: during tests email is saved in django.core.mail.outbox and no real email is sent
 
-# make tests faster
-SOUTH_TESTS_MIGRATE = False
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': join(dirname(__file__), 'test.db'),
-        'TEST_NAME': join(dirname(__file__), 'test.db'),
+        'NAME': 'icommons_ext_tools.db.sqlite3',
     },
 }
 
 ISITES_LMS_URL = ''
 
-QUALTRICS_LINK = {
-    'AGREEMENT_ID' : SECURE_SETTINGS.get('qualtrics_agreement_id', None),
-    'QUALTRICS_APP_KEY' : SECURE_SETTINGS.get('qualtrics_app_key', None),
-    'QUALTRICS_API_URL' : SECURE_SETTINGS.get('qualtrics_api_url', None),
-    'QUALTRICS_API_USER' : SECURE_SETTINGS.get('qualtrics_api_user', None),
-    'QUALTRICS_API_TOKEN' : SECURE_SETTINGS.get('qualtrics_api_token', None),
-    'QUALTRICS_AUTH_GROUP' : SECURE_SETTINGS.get('qualtrics_auth_group', None),
-    'USER_DECLINED_TERMS_URL' : 'ql:internal', # only in QA
-    'USER_ACCEPTED_TERMS_URL' : 'ql:internal', # only in QA
-}
-
-CANVAS_EMAIL_NOTIFICATION = {
-    'from_email_address'    : 'icommons-bounces@harvard.edu',
-    'support_email_address' : 'tlt_support@harvard.edu',
-    'course_migration_success_subject'  : 'Course site is ready : (TEST, PLEASE IGNORE)',
-    'course_migration_success_body'     : 'Success! \nYour new Canvas course site has been created and is ready for you at:\n'+
-            ' {0} \n\n Here are some resources for getting started with your site:\n http://tlt.harvard.edu/getting-started#teachingstaff',
-    'course_migration_failure_subject'  : 'Course site not created (TEST, PLEASE IGNORE) ',
-    'course_migration_failure_body'     : 'There was a problem creating your course site in Canvas.\n'+
-            'Your local academic support staff has been notified and will be in touch with you.\n\n'+
-            'If you have questions please contact them at:\n'+
-            ' FAS: atg@fas.harvard.edu\n'+
-            ' DCE: academictechnology@dce.harvard.edu\n'+
-            ' (Let them know that course site creation failed for sis_course_id: {0} ',
-    'support_email_subject_on_failure'  : 'TLT: Course site not created (TEST, PLEASE IGNORE) ',
-    'support_email_body_on_failure'     : 'There was a problem creating a course site in Canvas via the wizard.\n\n'+
-            'Course site creation failed for sis_course_id: {0}\n'+
-            'User: {1}\n'+
-            '{2}\n'+
-            'Environment: Test\n',
-}
+# NOTE: once the canvas_course_wizard application is removed we can eliminate it's
+# inclusion below.  Only reason to include it here is to allow for unit tests to work.
+INSTALLED_APPS += (
+    'canvas_course_wizard',
+)

--- a/manage.py
+++ b/manage.py
@@ -4,9 +4,9 @@ import sys
 
 if __name__ == "__main__":
     if 'test' in sys.argv:
-        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "icommons_ext_tools.settings.test_settings")
+        os.environ['DJANGO_SETTINGS_MODULE'] = 'icommons_ext_tools.settings.test_settings'
     else:
-        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "icommons_ext_tools.settings.local")
+        os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'icommons_ext_tools.settings.local')
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
...e to the fact that the Jenkins environment has an empty secure settings file.  Developers should be able to reset the affected settings keys on a per-test basis if needed.  Also, explicitly set DJANGO_SETTINGS_MODULE to test_settings in the event that the word "test" is present when calling manage.py (as opposed to setting a default value).  Move SDK dependency into base requirements file with same version as in production settings.  Add mock as well for testing purposes.  Skip over the tests in deprecated canvas_wizard application.  Install the canvas_course_wizard app in test_settings so that tests run, even though is app is also deprecated.  When both are removed, we can get rid of the line that installs the latter.  In base settings file, use a get method with SECURE_SETTINGS mapping so that tests can run in an environment w/o secure settings.  Instead of saying ".get(value, None)" just use ".get" since by default None is returned.  Move email notification block down further in file to be in same area as other app config blocks.