### PR TITLE
added TERM_TOOL_BASE_URL to settings files

### DIFF
--- a/icommons_ext_tools/settings/base.py
+++ b/icommons_ext_tools/settings/base.py
@@ -238,6 +238,8 @@ CANVAS_URL = SECURE_SETTINGS.get('canvas_url', 'https://changeme')
 
 COURSE_WIZARD = {
     'OLD_LMS_URL': SECURE_SETTINGS.get('old_lms_url'),
+    'TERM_TOOL_BASE_URL' : 'https://isites.harvard.edu',
+
 }
 
 CANVAS_WIZARD = {

--- a/icommons_ext_tools/settings/local.py
+++ b/icommons_ext_tools/settings/local.py
@@ -18,6 +18,8 @@ CANVAS_EMAIL_NOTIFICATION['course_migration_failure_subject'] += ' (TEST, PLEASE
 CANVAS_EMAIL_NOTIFICATION['support_email_subject_on_failure'] += ' (TEST, PLEASE IGNORE)'
 CANVAS_EMAIL_NOTIFICATION['environment'] = 'Local'
 
+COURSE_WIZARD['TERM_TOOL_BASE_URL'] = 'https://localhost:8000'
+
 DATABASES = {
 
     'default': {

--- a/icommons_ext_tools/settings/qa.py
+++ b/icommons_ext_tools/settings/qa.py
@@ -12,6 +12,8 @@ CANVAS_EMAIL_NOTIFICATION['course_migration_failure_subject'] += ' (TEST, PLEASE
 CANVAS_EMAIL_NOTIFICATION['support_email_subject_on_failure'] += ' (TEST, PLEASE IGNORE)'
 CANVAS_EMAIL_NOTIFICATION['environment'] = 'QA'
 
+COURSE_WIZARD['TERM_TOOL_BASE_URL'] = 'https://qa.tlt.harvard.edu'
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.oracle',

--- a/icommons_ext_tools/settings/test.py
+++ b/icommons_ext_tools/settings/test.py
@@ -14,6 +14,8 @@ CANVAS_EMAIL_NOTIFICATION['course_migration_failure_subject'] += ' (TEST, PLEASE
 CANVAS_EMAIL_NOTIFICATION['support_email_subject_on_failure'] += ' (TEST, PLEASE IGNORE)'
 CANVAS_EMAIL_NOTIFICATION['environment'] = 'Test'
 
+COURSE_WIZARD['TERM_TOOL_BASE_URL'] = 'https://test.tlt.harvard.edu'
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.oracle',


### PR DESCRIPTION
This is the base url for each env to allow us to build the link to the term tool edit page. The view that uses this setting is in the django canvas course wizard app which is included by this project.