### PR TITLE
Sprint 26 TLT-1777 Incrementing package versions

### DIFF
--- a/icommons_ext_tools/requirements/demo.txt
+++ b/icommons_ext_tools/requirements/demo.txt
@@ -9,6 +9,6 @@ newrelic==2.8.0.7
 gunicorn
 
 # Note: In the demo environment we use the /master branch
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.11#egg=django-icommons-common
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.12#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.8.3#egg=django-icommons-ui
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v1.3.5#egg=django-canvas-course-site-wizard
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v1.3.6#egg=django-canvas-course-site-wizard

--- a/icommons_ext_tools/requirements/production.txt
+++ b/icommons_ext_tools/requirements/production.txt
@@ -8,6 +8,6 @@ newrelic==2.8.0.7
 
 gunicorn
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.11#egg=django-icommons-common
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.12#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.8.3#egg=django-icommons-ui
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v1.3.5#egg=django-canvas-course-site-wizard
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v1.3.6#egg=django-canvas-course-site-wizard


### PR DESCRIPTION
Incrementing django-canvas-course-site-wizard and django-icommons-common versions for course info block feature.

Depends on PRs:

https://github.com/Harvard-University-iCommons/django-icommons-common/pull/72
https://github.com/Harvard-University-iCommons/django-canvas-course-site-wizard/pull/100