### PR TITLE
pulls updated version of dcccw with fixed unit tests

### DIFF
--- a/icommons_ext_tools/requirements/demo.txt
+++ b/icommons_ext_tools/requirements/demo.txt
@@ -10,4 +10,4 @@ gunicorn
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.14#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.8.3#egg=django-icommons-ui
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v1.3.6#egg=django-canvas-course-site-wizard
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v1.3.7#egg=django-canvas-course-site-wizard

--- a/icommons_ext_tools/requirements/production.txt
+++ b/icommons_ext_tools/requirements/production.txt
@@ -10,4 +10,4 @@ gunicorn
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.14#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.8.3#egg=django-icommons-ui
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v1.3.6#egg=django-canvas-course-site-wizard
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v1.3.7#egg=django-canvas-course-site-wizard


### PR DESCRIPTION
Dependent upon a new tagged version of dcccw (v1.3.7), PR for that is here: https://github.com/Harvard-University-iCommons/django-canvas-course-site-wizard/pull/103