### PR TITLE
removed dccsw app and cleaned up related settings. Also move database…

### DIFF
--- a/icommons_ext_tools/settings/base.py
+++ b/icommons_ext_tools/settings/base.py
@@ -87,11 +87,11 @@ MANAGERS = ADMINS
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.oracle',
-        'NAME': SECURE_SETTINGS.get('db_default_name'),
-        'USER': SECURE_SETTINGS.get('db_default_user'),
-        'PASSWORD': SECURE_SETTINGS.get('db_default_pass'),
-        'HOST': SECURE_SETTINGS.get('db_default_host'),
-        'PORT': SECURE_SETTINGS.get('db_default_port'),
+        'NAME': SECURE_SETTINGS.get('django_db_name'),
+        'USER': SECURE_SETTINGS.get('django_db_user'),
+        'PASSWORD': SECURE_SETTINGS.get('django_db_pass'),
+        'HOST': SECURE_SETTINGS.get('django_db_host'),
+        'PORT': SECURE_SETTINGS.get('django_db_port'),
         'OPTIONS': {
             'threaded': True,
         },

--- a/icommons_ext_tools/settings/base.py
+++ b/icommons_ext_tools/settings/base.py
@@ -41,6 +41,9 @@ ADMINS = (
 # email output if EMAIL_BACKEND is filebased.EmailBackend
 _LOG_ROOT = SECURE_SETTINGS.get('log_root', '')
 
+#Debug setting
+DEBUG = SECURE_SETTINGS.get('enable_debug', False)
+
 # This is the address that admin emails (sent to the addresses in the ADMINS list) will be sent 'from'.
 # It can be overridden in specific settings files to indicate what environment
 # is producing admin emails (e.g. 'app env <email>').
@@ -79,7 +82,22 @@ EMAIL_PORT = SECURE_SETTINGS.get('email_port', 25)
 
 MANAGERS = ADMINS
 
-# DATABASES are defined in individual environment settings
+# DATABASES
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.oracle',
+        'NAME': SECURE_SETTINGS.get('db_default_name'),
+        'USER': SECURE_SETTINGS.get('db_default_user'),
+        'PASSWORD': SECURE_SETTINGS.get('db_default_pass'),
+        'HOST': SECURE_SETTINGS.get('db_default_host'),
+        'PORT': SECURE_SETTINGS.get('db_default_port'),
+        'OPTIONS': {
+            'threaded': True,
+        },
+        'CONN_MAX_AGE': 0,
+    }
+}
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
@@ -213,7 +231,6 @@ INSTALLED_APPS = (
     'icommons_ui',
     'qualtrics_link',
     'crispy_forms',
-    'canvas_course_site_wizard',
 )
 
 # session cookie lasts for 7 hours (in seconds)
@@ -239,10 +256,6 @@ ICOMMONS_COMMON = {
 # default to a bogus url.
 CANVAS_URL = SECURE_SETTINGS.get('canvas_url', 'https://changeme')
 
-COURSE_WIZARD = {
-    'TERM_TOOL_BASE_URL' : 'https://isites.harvard.edu',
-}
-
 CANVAS_SITE_SETTINGS = {
     'base_url': CANVAS_URL + '/',
 }
@@ -254,46 +267,6 @@ CANVAS_SDK_SETTINGS = {
     'per_page': 1000,
 }
 
-CANVAS_EMAIL_NOTIFICATION = {
-    'from_email_address': 'icommons-bounces@harvard.edu',
-    'support_email_address': 'tlt_support@harvard.edu',
-    'course_migration_success_subject': 'Course site is ready',
-    'course_migration_success_body': 'Success! \nYour new Canvas course site has been created and is ready for you at:\n'+
-            ' {0} \n\n Here are some resources for getting started with your site:\n http://tlt.harvard.edu/getting-started#teachingstaff',
-
-    'course_migration_failure_subject': 'Course site not created',
-    'course_migration_failure_body': 'There was a problem creating your course site in Canvas.\n'+
-            'Your local academic support staff has been notified and will be in touch with you.\n\n'+
-            'If you have questions please contact them at:\n'+
-            ' FAS: atg@fas.harvard.edu\n'+
-            ' DCE/Summer: AcademicTechnology@dce.harvard.edu\n'+
-            ' (Let them know that course site creation failed for sis_course_id: {0} ',
-
-    'support_email_subject_on_failure': 'Course site not created',
-    'support_email_body_on_failure': 'There was a problem creating a course site in Canvas via the wizard.\n\n'+
-            'Course site creation failed for sis_course_id: {0}\n'+
-            'User: {1}\n'+
-            '{2}\n'+
-            'Environment: {3}\n',
-    'environment' : 'Production',
-}
-
-BULK_COURSE_CREATION = {
-    'log_long_running_jobs': True,
-    'long_running_age_in_minutes': 30,
-    'notification_email_subject': 'Sites created for {school} {term} term',
-    'notification_email_body': 'Canvas course sites have been created for the '
-                               '{school} {term} term.\n\n - {success_count} '
-                               'course sites were created successfully.\n',
-    'notification_email_body_failed_count': ' - {} course sites were not '
-                                            'created.',
-}
-
-# Background task PID (lock) files
-#   * If created in another directory, ensure the directory exists in runtime environment
-PROCESS_ASYNC_JOBS_PID_FILE = 'process_async_jobs.pid'
-FINALIZE_BULK_CREATE_JOBS_PID_FILE = 'finalize_bulk_create_jobs.pid'
-
 QUALTRICS_LINK = {
     'AGREEMENT_ID': SECURE_SETTINGS.get('qualtrics_agreement_id'),
     'QUALTRICS_APP_KEY': SECURE_SETTINGS.get('qualtrics_app_key'),
@@ -301,8 +274,8 @@ QUALTRICS_LINK = {
     'QUALTRICS_API_USER': SECURE_SETTINGS.get('qualtrics_api_user'),
     'QUALTRICS_API_TOKEN': SECURE_SETTINGS.get('qualtrics_api_token'),
     'QUALTRICS_AUTH_GROUP': SECURE_SETTINGS.get('qualtrics_auth_group'),
-    'USER_DECLINED_TERMS_URL': 'ql:internal',
-    'USER_ACCEPTED_TERMS_URL': 'ql:internal',
+    'USER_DECLINED_TERMS_URL': SECURE_SETTINGS.get('qualtrics_user_declined_terms_url'),
+    'USER_ACCEPTED_TERMS_URL': SECURE_SETTINGS.get('qualtrics_user_accepted_terms_url'),
 }
 
 _DEFAULT_LOG_LEVEL = SECURE_SETTINGS.get('log_level', 'DEBUG')

--- a/icommons_ext_tools/settings/local.py
+++ b/icommons_ext_tools/settings/local.py
@@ -3,48 +3,9 @@ from .base import *
 # To allow local development server to load static files with DEBUG=False, run:
 #   manage.py runserver --insecure
 # Note: this should never be done for anything but protected local development purposes.
-DEBUG = True
+
 TEMPLATE_DEBUG = DEBUG
 CRISPY_FAIL_SILENTLY = not DEBUG
-
-# LOG_ROOT used for log file storage; EMAIL_FILE_PATH used for
-# email output if EMAIL_BACKEND is filebased.EmailBackend
-
-ISITES_LMS_URL = 'http://isites.harvard.edu/'
-
-
-CANVAS_EMAIL_NOTIFICATION['course_migration_success_subject'] += ' (TEST, PLEASE IGNORE)'
-CANVAS_EMAIL_NOTIFICATION['course_migration_failure_subject'] += ' (TEST, PLEASE IGNORE)'
-CANVAS_EMAIL_NOTIFICATION['support_email_subject_on_failure'] += ' (TEST, PLEASE IGNORE)'
-CANVAS_EMAIL_NOTIFICATION['environment'] = 'Local'
-CANVAS_EMAIL_NOTIFICATION['support_email_address'] = 'tltqaemails@g.harvard.edu'
-
-COURSE_WIZARD['TERM_TOOL_BASE_URL'] = 'https://localhost:8000'
-
-DATABASES = {
-
-    'default': {
-        'ENGINE': 'django.db.backends.oracle',
-
-        'NAME': 'isiteqa',
-        'USER': SECURE_SETTINGS['django_db_user'],
-        'PASSWORD': SECURE_SETTINGS['django_db_pass'],
-        'HOST': 'icd3.isites.harvard.edu',
-
-        'PORT': '8003',
-        'OPTIONS': {
-            'threaded': True,
-        },
-
-        'CONN_MAX_AGE': 0,
-    }
-}
-
-DATABASE_ROUTERS = ['icommons_common.routers.DatabaseAppsRouter']
-DATABASE_APPS_MAPPING = {
-    'canvas_course_site_wizard': 'default',
-}
-DATABASE_MIGRATION_WHITELIST = ['default']
 
 # need to override the NLS_DATE_FORMAT that is set by oraclepool
 '''
@@ -54,9 +15,7 @@ DATABASE_EXTRAS = {
 }
 '''
 
-INSTALLED_APPS += (
-    'debug_toolbar',
-)
+INSTALLED_APPS += ('debug_toolbar',)
 
 MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 
@@ -74,8 +33,3 @@ CACHES = {
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.file'
 
-'''
-The dictionary below contains group id's and school names.
-These are the groups that are allowed to edit term informtion.
-The school must be the same as the school_id in the school model.
-'''

--- a/icommons_ext_tools/settings/production.py
+++ b/icommons_ext_tools/settings/production.py
@@ -4,33 +4,6 @@ DEBUG = False
 
 ALLOWED_HOSTS = ['*']
 
-# Update qualtrics term urls in prod
-QUALTRICS_LINK['USER_DECLINED_TERMS_URL'] = 'http://surveytools.harvard.edu'
-QUALTRICS_LINK['USER_ACCEPTED_TERMS_URL'] = 'ql:launch'
-
-ISITES_LMS_URL = 'http://isites.harvard.edu/'
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.oracle',
-        'NAME': 'isitedgd',
-        'USER': SECURE_SETTINGS.get('django_db_user'),
-        'PASSWORD': SECURE_SETTINGS.get('django_db_pass'),
-        'HOST': 'dbnode3.isites.harvard.edu',
-        'PORT': '8003',
-        'OPTIONS': {
-            'threaded': True,
-        },
-        'CONN_MAX_AGE': 0,
-    }
-}
-
-DATABASE_ROUTERS = ['icommons_common.routers.DatabaseAppsRouter']
-DATABASE_APPS_MAPPING = {
-    'canvas_course_site_wizard': 'default',
-}
-DATABASE_MIGRATION_WHITELIST = ['default']
-
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache',

--- a/icommons_ext_tools/settings/qa.py
+++ b/icommons_ext_tools/settings/qa.py
@@ -1,40 +1,6 @@
-
 from .base import *
 
-DEBUG = False
-
 ALLOWED_HOSTS = ['*']
-
-ISITES_LMS_URL = 'http://qa.isites.harvard.edu/'
-
-CANVAS_EMAIL_NOTIFICATION['course_migration_success_subject'] += ' (TEST, PLEASE IGNORE)'
-CANVAS_EMAIL_NOTIFICATION['course_migration_failure_subject'] += ' (TEST, PLEASE IGNORE)'
-CANVAS_EMAIL_NOTIFICATION['support_email_subject_on_failure'] += ' (TEST, PLEASE IGNORE)'
-CANVAS_EMAIL_NOTIFICATION['environment'] = 'QA'
-CANVAS_EMAIL_NOTIFICATION['support_email_address'] = 'tltqaemails@g.harvard.edu'
-
-COURSE_WIZARD['TERM_TOOL_BASE_URL'] = 'https://qa.tlt.harvard.edu'
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.oracle',
-        'NAME': 'isiteqa',
-        'USER': SECURE_SETTINGS['django_db_user'],
-        'PASSWORD': SECURE_SETTINGS['django_db_pass'],
-        'HOST': 'icd3.isites.harvard.edu',
-        'PORT': '8003',
-        'OPTIONS': {
-            'threaded': True,
-        },
-        'CONN_MAX_AGE': 0,
-    }
-}
-
-DATABASE_ROUTERS = ['icommons_common.routers.DatabaseAppsRouter']
-DATABASE_APPS_MAPPING = {
-    'canvas_course_site_wizard': 'default',
-}
-DATABASE_MIGRATION_WHITELIST = ['default']
 
 CACHES = {
     'default': {

--- a/icommons_ext_tools/settings/test.py
+++ b/icommons_ext_tools/settings/test.py
@@ -1,39 +1,7 @@
 # test.py
 from .base import *
-DEBUG = True
 
 ALLOWED_HOSTS = ['*']
-
-ISITES_LMS_URL = 'http://qa.isites.harvard.edu/'
-
-CANVAS_EMAIL_NOTIFICATION['course_migration_success_subject'] += ' (TEST, PLEASE IGNORE)'
-CANVAS_EMAIL_NOTIFICATION['course_migration_failure_subject'] += ' (TEST, PLEASE IGNORE)'
-CANVAS_EMAIL_NOTIFICATION['support_email_subject_on_failure'] += ' (TEST, PLEASE IGNORE)'
-CANVAS_EMAIL_NOTIFICATION['environment'] = 'Test'
-CANVAS_EMAIL_NOTIFICATION['support_email_address'] = 'tltqaemails@g.harvard.edu'
-
-COURSE_WIZARD['TERM_TOOL_BASE_URL'] = 'https://test.tlt.harvard.edu'
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.oracle',
-        'NAME': 'isiteqa',
-        'USER': SECURE_SETTINGS.get('django_db_user', None),
-        'PASSWORD': SECURE_SETTINGS.get('django_db_pass', None),
-        'HOST': 'icd3.isites.harvard.edu',
-        'PORT': '8003',
-        'OPTIONS': {
-            'threaded': True,
-        },
-        'CONN_MAX_AGE': 0,
-    }
-}
-
-DATABASE_ROUTERS = ['icommons_common.routers.DatabaseAppsRouter']
-DATABASE_APPS_MAPPING = {
-    'canvas_course_site_wizard': 'default',
-}
-DATABASE_MIGRATION_WHITELIST = ['default']
 
 CACHES = {
     'default': {

--- a/icommons_ext_tools/settings/test_settings.py
+++ b/icommons_ext_tools/settings/test_settings.py
@@ -11,4 +11,3 @@ DATABASES = {
     },
 }
 
-ISITES_LMS_URL = ''

--- a/icommons_ext_tools/urls.py
+++ b/icommons_ext_tools/urls.py
@@ -1,14 +1,10 @@
 from django.conf.urls import (patterns, include, url)
 from django.contrib import admin
 
-from canvas_course_site_wizard import urls as ccsw_urls
-
-
 admin.autodiscover()
 
 urlpatterns = patterns(
     '',
-    url(r'^ext_tools/canvas-course-site-wizard/', include(ccsw_urls)),
     url(r'^ext_tools/not_authorized/', 'icommons_ui.views.not_authorized', name="not_authorized"),
     url(r'^ext_tools/pin/', include('icommons_common.auth.urls', namespace="pin")),
     url(r'^ext_tools/qualtrics_link/', include('qualtrics_link.urls', namespace="ql")),


### PR DESCRIPTION
… settings into base.py and added values to secure.py copying the format used in lti_tools. This means that secure.py needs to be updated with the new params for database before the tool will run.

moved two qualtrics settings to secure.py to clean up env files. 
'qualtrics_user_declined_terms_url' : 'ql:internal',   # prod value 'http://surveytools.harvard.edu'
'qualtrics_user_accepted_terms_url' : 'ql:internal',  # prod value 'ql:launch'
the prod values are listed next to the non-prod values. 

I also removed the database router, mapping, and whitelist settings. The project now only has one app 
Qualtrics, so it didn't seem necessary. 