### PR TITLE
tlt-2964: do not attempt to migrate icommons_common models

### DIFF
--- a/icommons_ext_tools/settings/base.py
+++ b/icommons_ext_tools/settings/base.py
@@ -113,8 +113,11 @@ DATABASES = {
 }
 
 DATABASE_ROUTERS = ['icommons_common.routers.DatabaseAppsRouter']
-DATABASE_APPS_MAPPING = {}
-DATABASE_MIGRATION_WHITELIST = ['default']
+DATABASE_APPS_MAPPING = {
+    'qualtrics_link': 'default',
+    'icommons_common': 'default'
+}
+DATABASE_MIGRATION_WHITELIST = []
 
 # Cache
 # https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-CACHES


### PR DESCRIPTION
Fixes an issue where Django was attempting to actually apply icommons_common model migrations. That was [causing deployments to fail](https://jenkins.tlt.harvard.edu/job/django-deploy/2427/consoleFull).

Note the `qualtrics_link` app has no models of its own defined, and uses termtool on the backend, so it can safely be left out of the whitelist as well.