### PR TITLE
Task/sapnamysore/tlt 3091/cas changes

### DIFF
--- a/icommons_ext_tools/requirements/base.txt
+++ b/icommons_ext_tools/requirements/base.txt
@@ -8,5 +8,5 @@ ndg-httpsclient==0.4.2
 pycrypto==2.6.1
 redis==2.10.5
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.10#egg=canvas-python-sdk==0.10
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.17#egg=django-icommons-common==v1.17
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.3#egg=django-icommons-ui==1.3
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.31#egg=django-icommons-common==1.31
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.4#egg=django-icommons-ui==1.4

--- a/icommons_ext_tools/settings/base.py
+++ b/icommons_ext_tools/settings/base.py
@@ -42,6 +42,7 @@ EMAIL_SUBJECT_PREFIX = ''
 # Application definition
 
 INSTALLED_APPS = (
+    'django_cas_ng',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -67,10 +68,16 @@ MIDDLEWARE_CLASSES = (
 )
 
 AUTHENTICATION_BACKENDS = (
-    'icommons_common.auth.backends.PINAuthBackend',
+    'django.contrib.auth.backends.ModelBackend',
+    'icommons_common.auth.backends.CASAuthBackend',
+
 )
 
-LOGIN_URL = reverse_lazy('pin:login')
+#CAS plugin attributes
+CAS_SERVER_URL = SECURE_SETTINGS.get('cas_server_url', 'https://www.pin1.harvard.edu/cas/')
+CAS_LOGOUT_URL = SECURE_SETTINGS.get('cas_logout_url','https://www.pin1.harvard.edu/cas/logout')
+CAS_LOGGED_MSG = False
+CAS_LOGIN_MSG = None
 
 TEMPLATES = [
     {
@@ -84,7 +91,6 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                'icommons_common.auth.context_processors.pin_context',
             ],
         },
     },

--- a/icommons_ext_tools/urls.py
+++ b/icommons_ext_tools/urls.py
@@ -1,13 +1,19 @@
 from django.conf.urls import (
     include,
     url)
+from django_cas_ng import views as cas_ng_views
+
 from icommons_ui import views as ui_views
 from qualtrics_link import urls as ql_urls
+import django_cas_ng
+
 
 urlpatterns = [
+    url(r'^accounts/login/', django_cas_ng.views.login, name='cas_ng_login'),
+    url(r'^accounts/logout/', django_cas_ng.views.logout, name='cas_ng_logout'),
     url(r'^ext_tools/not_authorized/', ui_views.not_authorized, name="not_authorized"),
-    url(r'^ext_tools/pin/', include('icommons_common.auth.urls', namespace="pin")),
     url(r'^ext_tools/qualtrics_link/', include(ql_urls, namespace="ql")),
+
 ]
 
 handler403 = 'icommons_ext_tools.views.handler403'

--- a/icommons_ext_tools/urls.py
+++ b/icommons_ext_tools/urls.py
@@ -1,12 +1,11 @@
+import django_cas_ng
 from django.conf.urls import (
     include,
     url)
 from django_cas_ng import views as cas_ng_views
-
 from icommons_ui import views as ui_views
-from qualtrics_link import urls as ql_urls
-import django_cas_ng
 
+from qualtrics_link import urls as ql_urls
 
 urlpatterns = [
     url(r'^accounts/login/', django_cas_ng.views.login, name='cas_ng_login'),


### PR DESCRIPTION
Migrate the apps in icommons_ext_tools to use Harvard Key instead of iSites PIN proxy. This rep is using Django 1.10.5, so there was a slight change in the way the urlpatterns are set. 

https://jira.huit.harvard.edu/browse/TLT-3091

@cmurtaugh 