### PR TITLE
Set the django_cas_ng plugin to use CAS version 3

### DIFF
--- a/icommons_ext_tools/requirements/base.txt
+++ b/icommons_ext_tools/requirements/base.txt
@@ -7,6 +7,7 @@ hiredis==0.2.0
 ndg-httpsclient==0.4.2
 pycrypto==2.6.1
 redis==2.10.5
+lxml==3.8.0
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.10#egg=canvas-python-sdk==0.10
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.31#egg=django-icommons-common==1.31
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.4#egg=django-icommons-ui==1.4

--- a/icommons_ext_tools/settings/base.py
+++ b/icommons_ext_tools/settings/base.py
@@ -75,8 +75,8 @@ AUTHENTICATION_BACKENDS = (
 
 #CAS plugin attributes
 CAS_SERVER_URL = SECURE_SETTINGS.get('cas_server_url', 'https://www.pin1.harvard.edu/cas/')
-CAS_LOGOUT_URL = SECURE_SETTINGS.get('cas_logout_url','https://www.pin1.harvard.edu/cas/logout')
-CAS_LOGGED_MSG = False
+CAS_VERSION = '3'
+CAS_LOGGED_MSG = None
 CAS_LOGIN_MSG = None
 
 TEMPLATES = [


### PR DESCRIPTION
to get around the SSO bug when logging out of CAS - see mingchen/django-cas-ng#82 for details.  Remove unused/unsupported CAS_LOGOUT_URL parameter.  Add lxml as a required library so the logout callback works with v3 - see mingchen/django-cas-ng#110 for an example of why we need it.

@Chris-Thornton-Harvard @cmurtaugh 