### PR TITLE
TLT-2838 Qualtrics Role and Division fix and School Affiliation Migrations

### DIFF
--- a/qualtrics_link/forms.py
+++ b/qualtrics_link/forms.py
@@ -1,5 +1,5 @@
 from django import forms
 
+
 class SpoofForm(forms.Form):
     huid = forms.CharField(max_length=15, required=False)
-    

--- a/qualtrics_link/templates/qualtrics_link/launch.html
+++ b/qualtrics_link/templates/qualtrics_link/launch.html
@@ -1,8 +1,0 @@
-<html>
-<head>
-<title>Hello</title>
-</head>
-<body>
-	<h2>Hello 2</h2>
-</body>
-</html>

--- a/qualtrics_link/templates/qualtrics_link/main.html
+++ b/qualtrics_link/templates/qualtrics_link/main.html
@@ -58,10 +58,14 @@
 	<tr>
 		<td valign="top">
 			<table class="table table-striped table-hover">
-			 	<caption>iCommons API Data</caption>
-			    {% for key,value in  person.items %}
-			    <tr> <th>{{key}}</th><td>{{value}}</td></tr> 
-			    {% endfor %}
+			 	<caption>People Data</caption>
+				<tr> <th>First name</th><td>{{person.name_first}}</td></tr>
+				<tr> <th>Last name</th><td>{{person.name_last}}</td></tr>
+				<tr> <th>Email</th><td>{{person.email_address}}</td></tr>
+				<tr> <th>Role</th><td>{{person.role_type_cd}}</td></tr>
+				<tr> <th>Division</th><td>{{person.department}}</td></tr>
+				<tr> <th>School affiliations</th><td>{{processed_data.school_affiliations}}</td></tr>
+				<tr> <th>ID</th><td>{{person.univ_id}}</td></tr>
 			</table>
 			<p><a href="{{ssotestlink}}" class="btn btn-primary">Qualtrics SSO test Link</a></p>
 			<p><a href="{{qualtricslink}}" class="btn btn-primary">Qualtrics Survey Link</a></p>
@@ -70,10 +74,13 @@
 			 <table class="table table-striped table-hover">
 			 	<caption>Processed Data</caption>
 			   	<tr> <th>user_id</th><td>{{huid}} </td></tr> 
-			    <tr> <th>authenticated</th><td>{{request.user.is_authenticated}}</td></tr> 
-			    {% for key,value in  keyValueDict.items %}
-			    <tr> <th>{{key}}</th><td>{{value}}</td></tr> 
-			    {% endfor %}
+			    <tr> <th>authenticated</th><td>{{request.user.is_authenticated}}</td></tr>
+				<tr> <th>First name</th><td>{{processed_data.first_name}}</td></tr>
+				<tr> <th>Last name</th><td>{{processed_data.last_name}}</td></tr>
+				<tr> <th>Email</th><td>{{processed_data.email}}</td></tr>
+				<tr> <th>Role</th><td>{{processed_data.role}}</td></tr>
+				<tr> <th>Division</th><td>{{processed_data.division}}</td></tr>
+				<tr> <th>ID</th><td>{{processed_data.id}}</td></tr>
 			    <tr><th>user_in_whitelist</th><td>{{user_in_whitelist}}</td></tr>
 			</table>
 		</td>

--- a/qualtrics_link/templates/qualtrics_link/main.html
+++ b/qualtrics_link/templates/qualtrics_link/main.html
@@ -63,7 +63,7 @@
 				<tr> <th>Last name</th><td>{{person.name_last}}</td></tr>
 				<tr> <th>Email</th><td>{{person.email_address}}</td></tr>
 				<tr> <th>Role</th><td>{{person.role_type_cd}}</td></tr>
-				<tr> <th>Division</th><td>{{person.department}}</td></tr>
+				<tr> <th>Department</th><td>{{person.department}}</td></tr>
 				<tr> <th>School affiliations</th><td>{{processed_data.school_affiliations}}</td></tr>
 				<tr> <th>ID</th><td>{{person.univ_id}}</td></tr>
 			</table>

--- a/qualtrics_link/templates/qualtrics_link/main.html
+++ b/qualtrics_link/templates/qualtrics_link/main.html
@@ -81,6 +81,8 @@
 				<tr> <th>Role</th><td>{{processed_data.role}}</td></tr>
 				<tr> <th>Division</th><td>{{processed_data.division}}</td></tr>
 				<tr> <th>ID</th><td>{{processed_data.id}}</td></tr>
+				<tr> <th>Valid School</th><td>{{processed_data.valid_school}}</td></tr>
+				<tr> <th>Valid Dept</th><td>{{processed_data.valid_dept}}</td></tr>
 			    <tr><th>user_in_whitelist</th><td>{{user_in_whitelist}}</td></tr>
 			</table>
 		</td>

--- a/qualtrics_link/templates/qualtrics_link/notauthinternal.html
+++ b/qualtrics_link/templates/qualtrics_link/notauthinternal.html
@@ -46,6 +46,8 @@
 				<tr> <th>Role</th><td>{{processed_data.role}}</td></tr>
 				<tr> <th>Division</th><td>{{processed_data.division}}</td></tr>
 				<tr> <th>ID</th><td>{{processed_data.id}}</td></tr>
+				<tr> <th>Valid School</th><td>{{processed_data.valid_school}}</td></tr>
+				<tr> <th>Valid Dept</th><td>{{processed_data.valid_dept}}</td></tr>
 			    <tr><th>user_in_whitelist</th><td>{{user_in_whitelist}}</td></tr>
 			</table>
 		</td>

--- a/qualtrics_link/templates/qualtrics_link/notauthinternal.html
+++ b/qualtrics_link/templates/qualtrics_link/notauthinternal.html
@@ -22,22 +22,38 @@
 
 <br />
 <table>
-	<tr><td valign="top">
-<table class="table table-striped table-hover">
- 	<caption>iCommons API Data</caption>
-    {% for key,value in  person.items %}
-    <tr> <th>{{key}}</th><td>{{value}}</td></tr>
-    {% endfor %}
-</table>
-</td><td valign="top">
-<table class="table table-striped table-hover">
- 	<caption>Processed Data</caption>
-    {% for key,value in  processeddata.items %}
-    <tr> <th>{{key}}</th><td>{{value}}</td></tr>
-    {% endfor %}
-</table>
-</td>
-</tr>
+	<tr>
+		<td valign="top">
+			<table class="table table-striped table-hover">
+			 	<caption>People Data</caption>
+				<tr> <th>First name</th><td>{{person.name_first}}</td></tr>
+				<tr> <th>Last name</th><td>{{person.name_last}}</td></tr>
+				<tr> <th>Email</th><td>{{person.email_address}}</td></tr>
+				<tr> <th>Role</th><td>{{person.role_type_cd}}</td></tr>
+				<tr> <th>Division</th><td>{{person.department}}</td></tr>
+				<tr> <th>School affiliations</th><td>{{processed_data.school_affiliations}}</td></tr>
+				<tr> <th>ID</th><td>{{person.univ_id}}</td></tr>
+			</table>
+			<p><a href="{{ssotestlink}}" class="btn btn-primary">Qualtrics SSO test Link</a></p>
+			<p><a href="{{qualtricslink}}" class="btn btn-primary">Qualtrics Survey Link</a></p>
+		</td>
+		<td valign="top">
+			 <table class="table table-striped table-hover">
+			 	<caption>Processed Data</caption>
+			   	<tr> <th>user_id</th><td>{{huid}} </td></tr>
+			    <tr> <th>authenticated</th><td>{{request.user.is_authenticated}}</td></tr>
+				<tr> <th>First name</th><td>{{processed_data.first_name}}</td></tr>
+				<tr> <th>Last name</th><td>{{processed_data.last_name}}</td></tr>
+				<tr> <th>Email</th><td>{{processed_data.email}}</td></tr>
+				<tr> <th>Role</th><td>{{processed_data.role}}</td></tr>
+				<tr> <th>Division</th><td>{{processed_data.division}}</td></tr>
+				<tr> <th>ID</th><td>{{processed_data.id}}</td></tr>
+			    <tr><th>user_in_whitelist</th><td>{{user_in_whitelist}}</td></tr>
+			</table>
+		</td>
+		<td valign="top" id="data">
+		</td>
+	</tr>
 </table>
 <a href="{% url 'ql:internal' %}" class="btn btn-primary">Return to Survey Tools page</a>
 

--- a/qualtrics_link/templates/qualtrics_link/notauthinternal.html
+++ b/qualtrics_link/templates/qualtrics_link/notauthinternal.html
@@ -30,12 +30,10 @@
 				<tr> <th>Last name</th><td>{{person.name_last}}</td></tr>
 				<tr> <th>Email</th><td>{{person.email_address}}</td></tr>
 				<tr> <th>Role</th><td>{{person.role_type_cd}}</td></tr>
-				<tr> <th>Division</th><td>{{person.department}}</td></tr>
+				<tr> <th>Department</th><td>{{person.department}}</td></tr>
 				<tr> <th>School affiliations</th><td>{{processed_data.school_affiliations}}</td></tr>
 				<tr> <th>ID</th><td>{{person.univ_id}}</td></tr>
 			</table>
-			<p><a href="{{ssotestlink}}" class="btn btn-primary">Qualtrics SSO test Link</a></p>
-			<p><a href="{{qualtricslink}}" class="btn btn-primary">Qualtrics Survey Link</a></p>
 		</td>
 		<td valign="top">
 			 <table class="table table-striped table-hover">

--- a/qualtrics_link/tests.py
+++ b/qualtrics_link/tests.py
@@ -1,6 +1,5 @@
 from django.test import TestCase
 import qualtrics_link.util as util
-from unittest import skip
 
 
 class UtilTestCase(TestCase):
@@ -32,25 +31,12 @@ class UtilTestCase(TestCase):
         self.assertEqual(util.get_valid_dept(None), 'Other')
         self.assertIsNone(util.get_valid_dept('HMS'))
 
-    @skip("Skipping until changes are made in view and util")
-    def test_build_user_dict(self):
-        people_in_data = {
-            'people': [
-                {
-                    'first_name': 'firstName',
-                    'last_name': 'lastName',
-                    'schoolAfilliations': [],
-                    'departmentAffiliation': 'UIS'
-                },
-            ]
-        }
-        return_dict = {
-            'first_name': 'firstName',
-            'last_name': 'lastName',
-            'division': 'HUIT',
-            'role': 'employee',
-            'validschool': False,
-            'validdept': True,
-        }
-        pass
-        self.assertEqual(util.build_user_dict(people_in_data), return_dict)
+    def test_lookup_school_affiliations(self):
+        # Test valid lookup
+        self.assertEqual(util.lookup_school_affiliations(39), 'DIV')
+
+        # Test empty employee school code
+        self.assertEqual(util.lookup_school_affiliations(92), '')
+
+        # Test invalid school code
+        self.assertEqual(util.lookup_school_affiliations(9999), 'Not Available')

--- a/qualtrics_link/tests.py
+++ b/qualtrics_link/tests.py
@@ -1,3 +1,56 @@
 from django.test import TestCase
+import qualtrics_link.util as util
+from unittest import skip
 
-# Create your tests here.
+
+class UtilTestCase(TestCase):
+
+    def test_lookup_unit(self):
+        self.assertEqual(util.lookup_unit('FAS'), 'FAS')
+        self.assertEqual(util.lookup_unit('DOES_NOT_EXIST'), 'Other')
+
+    def test_is_unit_valid(self):
+        self.assertTrue(util.is_unit_valid('HUIT'))
+        self.assertFalse(util.is_unit_valid('HBS'))
+        self.assertFalse(util.is_unit_valid('HMS'))
+        self.assertFalse(util.is_unit_valid('HSDM'))
+        self.assertFalse(util.is_unit_valid('HBP'))
+
+    def test_get_valid_school(self):
+        # User with multiple school affiliations, blacklist first
+        schools_blacklist_first = ['HMS', 'SUM', 'KSG']
+        self.assertEqual(util.get_valid_school(schools_blacklist_first), 'EXT')
+        # User with one school affiliation
+        schools_blacklist_first = ['KSG']
+        self.assertEqual(util.get_valid_school(schools_blacklist_first), 'HKS')
+        # User with no school affiliations
+        self.assertIsNone(util.get_valid_school([]))
+
+    def test_get_valid_dept(self):
+        self.assertEqual(util.get_valid_dept('MAG'), 'Central Administration',)
+        self.assertEqual(util.get_valid_dept('NO_AREA'), 'Other')
+        self.assertEqual(util.get_valid_dept(None), 'Other')
+        self.assertIsNone(util.get_valid_dept('HMS'))
+
+    @skip("Skipping until changes are made in view and util")
+    def test_build_user_dict(self):
+        people_in_data = {
+            'people': [
+                {
+                    'first_name': 'firstName',
+                    'last_name': 'lastName',
+                    'schoolAfilliations': [],
+                    'departmentAffiliation': 'UIS'
+                },
+            ]
+        }
+        return_dict = {
+            'first_name': 'firstName',
+            'last_name': 'lastName',
+            'division': 'HUIT',
+            'role': 'employee',
+            'validschool': False,
+            'validdept': True,
+        }
+        pass
+        self.assertEqual(util.build_user_dict(people_in_data), return_dict)

--- a/qualtrics_link/util.py
+++ b/qualtrics_link/util.py
@@ -1,5 +1,3 @@
-#
-# util.py
 import hashlib
 import hmac
 import base64
@@ -15,151 +13,157 @@ logger = logging.getLogger(__name__)
 
 BLACKLIST = set(['HBS', 'HMS', 'HSDM', 'HBP'])
 AREA_LOOKUP = {
-    'AAD' : 'HAA (Alumni Assoc.)',
-    'ADG' : 'Central Administration',
-    'ARB' : 'Central Administration',
-    'ART' : 'Central Administration',
-    'COL' : 'FAS',
-    'DCE' : 'EXT',
-    'DEF' : 'Central Administration',
-    'DES' : 'GSD',
-    'DIN' : 'Central Administration',
-    'DIV' : 'HDS',
-    'DOK' : 'Central Administration',
-    'EAS' : 'FAS',
-    'EAS' : 'FAS', 
-    'ECS' : 'EXT',
-    'EDU' : 'GSE',
-    'EXT' : 'EXT',
-    'FAS' : 'FAS',
-    'FCL' : 'Central Administration',
-    'FGS' : 'FAS',
-    'GSD' : 'GSD',
-    'GSE' : 'GSE',
-    'HAM' : 'Central Administration',
-    'HAS' : 'Central Administration',
-    'HBP' : 'HBS',
-    'HBS' : 'HBS',
-    'HCL' : 'FAS',
-    'HCU' : 'Central Administration',
-    'HDS' : 'HDS',
-    'HGR' : 'Central Administration',
-    'HIO' : 'Central Administration',
-    'HKS' : 'HKS',
-    'HLN' : 'Central Administration',
-    'HLS' : 'HLS',
-    'HMC' : 'Central Administration',
-    'HMS' : 'HMS',
-    'HRE' : 'Central Administration',
-    'HSDM' : 'HSDM',
-    'HSPH' : 'HSPH',
-    'HUIT' : 'HUIT',
-    'HUL' : 'Central Administration',
-    'HUP' : 'Central Administration',
-    'HUS' : 'Central Administration',
-    'HVN' : 'Central Administration',
-    'INI' : 'Central Administration',
-    'KSG' : 'HKS',
-    'LAS' : 'Central Administration',
-    'LAW' : 'HLS',
-    'LHF' : 'Central Administration',
-    'MAG' : 'Central Administration',
-    'MAR' : 'Central Administration',
-    'MEM' : 'Central Administration',
-    'NIE' : 'Central Administration',
-    'Not Available' : 'Other',
-    'OGB' : 'Central Administration',
-    'OGC' : 'Central Administration',
-    'OHR' : 'Central Administration',
-    'OPR' : 'Central Administration',
-    'Other' : 'Other',
-    'PAI' : 'Central Administration',
-    'POL' : 'Central Administration',
-    'RAD' : 'Radcliffe',
-    'SAO' : 'Central Administration',
-    'SDM' : 'HSDM',
-    'SPH' : 'HSPH',
-    'SPH' : 'HSPH',
-    'SUM' : 'EXT',
-    'TBD' : 'Central Administration',
-    'UHS' : 'Central Administration',
-    'UIS' : 'HUIT',
-    'UNP' : 'Central Administration',
-    'UOS' : 'Central Administration',
-    'UPO' : 'Central Administration',
-    'VIT' : 'Central Administration',
-    'VPA' : 'Central Administration',
-    'VPF' : 'Central Administration',
-    'VPG' : 'Central Administration',
+    'AAD': 'HAA (Alumni Assoc.)',
+    'ADG': 'Central Administration',
+    'ARB': 'Central Administration',
+    'ART': 'Central Administration',
+    'COL': 'FAS',
+    'DCE': 'EXT',
+    'DEF': 'Central Administration',
+    'DES': 'GSD',
+    'DIN': 'Central Administration',
+    'DIV': 'HDS',
+    'DOK': 'Central Administration',
+    'EAS': 'FAS',
+    'ECS': 'EXT',
+    'EDU': 'GSE',
+    'EXT': 'EXT',
+    'FAS': 'FAS',
+    'FCL': 'Central Administration',
+    'FGS': 'FAS',
+    'GSD': 'GSD',
+    'GSE': 'GSE',
+    'HAM': 'Central Administration',
+    'HAS': 'Central Administration',
+    'HBP': 'HBS',
+    'HBS': 'HBS',
+    'HCL': 'FAS',
+    'HCU': 'Central Administration',
+    'HDS': 'HDS',
+    'HGR': 'Central Administration',
+    'HIO': 'Central Administration',
+    'HKS': 'HKS',
+    'HLN': 'Central Administration',
+    'HLS': 'HLS',
+    'HMC': 'Central Administration',
+    'HMS': 'HMS',
+    'HRE': 'Central Administration',
+    'HSDM': 'HSDM',
+    'HSPH': 'HSPH',
+    'HUIT': 'HUIT',
+    'HUL': 'Central Administration',
+    'HUP': 'Central Administration',
+    'HUS': 'Central Administration',
+    'HVN': 'Central Administration',
+    'INI': 'Central Administration',
+    'KSG': 'HKS',
+    'LAS': 'Central Administration',
+    'LAW': 'HLS',
+    'LHF': 'Central Administration',
+    'MAG': 'Central Administration',
+    'MAR': 'Central Administration',
+    'MEM': 'Central Administration',
+    'NIE': 'Central Administration',
+    'Not Available': 'Other',
+    'OGB': 'Central Administration',
+    'OGC': 'Central Administration',
+    'OHR': 'Central Administration',
+    'OPR': 'Central Administration',
+    'Other': 'Other',
+    'PAI': 'Central Administration',
+    'POL': 'Central Administration',
+    'RAD': 'Radcliffe',
+    'SAO': 'Central Administration',
+    'SDM': 'HSDM',
+    'SPH': 'HSPH',
+    'SUM': 'EXT',
+    'TBD': 'Central Administration',
+    'UHS': 'Central Administration',
+    'UIS': 'HUIT',
+    'UNP': 'Central Administration',
+    'UOS': 'Central Administration',
+    'UPO': 'Central Administration',
+    'VIT': 'Central Administration',
+    'VPA': 'Central Administration',
+    'VPF': 'Central Administration',
+    'VPG': 'Central Administration',
 } 
 
 BS = 16
 pad = lambda s: s + (BS - len(s) % BS) * chr(BS - len(s) % BS) 
 
-def getencryptedhuid(huid):
+
+def get_encrypted_huid(huid):
     hasher = hashlib.md5()
     hasher.update(huid)
     encid = hasher.hexdigest()
     return encid
 
-def createencodedtoken(keyvaluepairs):
-    #reload(sys)
-    #sys.setdefaultencoding("utf-8")
+
+def create_encoded_token(key_value_pairs):
     key = settings.QUALTRICS_LINK.get('QUALTRICS_APP_KEY')
     secret = bytes(key)
-    keyvaluepairs = normalize('NFKD', keyvaluepairs).encode('ascii', 'ignore')
-    data = bytes(keyvaluepairs)
+    key_value_pairs = normalize('NFKD', key_value_pairs).encode('ascii', 'ignore')
+    data = bytes(key_value_pairs)
     encoded = base64.b64encode(hmac.new(secret, data).digest())
-    token = keyvaluepairs+'&mac='+encoded 
+    token = key_value_pairs+'&mac='+encoded
     raw = pad(token)
     cipher = AES.new(key, AES.MODE_ECB)
-    encodedtoken = base64.b64encode(cipher.encrypt(raw))
-    return urllib2.quote(encodedtoken.encode("utf8"),'') 
+    encoded_token = base64.b64encode(cipher.encrypt(raw))
+    return urllib2.quote(encoded_token.encode("utf8"),'')
 
-def getssotesturl(keyvaluepairs):
+
+def get_sso_test_url(key_value_pairs):
     key = settings.QUALTRICS_LINK.get('QUALTRICS_APP_KEY')
-    encodedtoken = createencodedtoken(keyvaluepairs)
-    ssotestlink = 'https://new.qualtrics.com/ControlPanel/ssoTest.php?key='+key+'&mac=md5&ssotoken='+encodedtoken
-    return ssotestlink
+    encoded_token = create_encoded_token(key_value_pairs)
+    sso_test_link = 'https://new.qualtrics.com/ControlPanel/ssoTest.php?key='+key+'&mac=md5&ssotoken='+encoded_token
+    return sso_test_link
 
-def getqualtricsurl(keyvaluepairs):
-    encodedtoken = createencodedtoken(keyvaluepairs)
-    qualtricsurl = 'https://harvard.qualtrics.com/ControlPanel/?ssotoken='+encodedtoken
-    logger.debug("qualtrics url is %s", qualtricsurl)
-    return qualtricsurl
 
-def getclientip(request):
+def get_qualtrics_url(key_value_pairs):
+    encoded_token = create_encoded_token(key_value_pairs)
+    qualtrics_url = 'https://harvard.qualtrics.com/ControlPanel/?ssotoken='+encoded_token
+    logger.debug("qualtrics url is %s", qualtrics_url)
+    return qualtrics_url
+
+
+def get_client_ip(request):
     x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
     if x_forwarded_for:
-        ipaddress = x_forwarded_for.split(',')[0]
+        ip_address = x_forwarded_for.split(',')[0]
     else:
-        ipaddress = request.META.get('REMOTE_ADDR')
-    return ipaddress
+        ip_address = request.META.get('REMOTE_ADDR')
+    return ip_address
 
-def lookupunit(unit):
+
+def lookup_unit(unit):
     if unit in AREA_LOOKUP:
         return AREA_LOOKUP[unit]
     else:
         logger.info('unit not found: {}'.format(unit))
         return 'Other'
 
-def isunitvalid(unit):
+
+def is_unit_valid(unit):
     if unit not in BLACKLIST:
         return True
     return False
 
-def getvalidschool(schools):
-    for schoolcode in schools:
-        school = lookupunit(schoolcode)
+
+def get_valid_school(schools):
+    for school_code in schools:
+        school = lookup_unit(school_code)
         if school not in BLACKLIST:
             return school
 
-def getvaliddept(dept):
-    division = lookupunit(dept)
+
+def get_valid_dept(dept):
+    division = lookup_unit(dept)
     if division not in BLACKLIST:
         return division
 
-def isuserinwhitelist(huid):
+
+def is_user_in_whitelist(huid):
     try:
         person = QualtricsAccessList.objects.get(user_id=huid)
         if person.expiration_date:
@@ -177,50 +181,39 @@ def isuserinwhitelist(huid):
         # the user is not in the whitelist'
         return False
 
-def builduserdict(data):
 
-    userdata = {}
-    
-    userdata['role'] = 'generic'
-    userdata['division'] = 'Other'
-    userdata['validschool'] = False
-    userdata['validdept'] = False
-    #userdata['schoolaffiliations'] = None
-    #userdata['departmentaffiliation'] = None
-    #userdata['personaffiliation'] = None
-    
+def build_user_dict(data):
+
+    user_data = {
+        'role': 'generic',
+        'division': 'Other',
+        'validschool': False,
+        'validdept': False
+    }
+
     if 'people' in data:
         person = data['people'][0]
         
-        userdata['firstname'] = person.get('firstName', 'Not Available')
-        userdata['lastname'] = person.get('lastName', 'Not Available')
-        userdata['email'] = person.get('email', 'Not Available')
+        user_data['firstname'] = person.get('firstName', 'Not Available')
+        user_data['lastname'] = person.get('lastName', 'Not Available')
+        user_data['email'] = person.get('email', 'Not Available')
 
-        #Person Affiliations check
-        #personaffiliation = person.get('personAffiliation', 'Not Available')
-        #if personaffiliation.lower() != 'not available':
-            #userdata['personaffiliation'] = personaffiliation
-            #userdata['role'] = personaffiliation
+        # School Affiliations check
+        school_affiliations = person.get('schoolAffiliations', 'Not Available')
 
-        #School Affiliations check    
-        schoolaffiliations = person.get('schoolAffiliations', 'Not Available')
-
-        #userdata['schoolaffiliations'] = schoolaffiliations
-        valid_school_code = getvalidschool(schoolaffiliations)
+        valid_school_code = get_valid_school(school_affiliations)
         if valid_school_code is not None:
-            userdata['validschool'] = True
-            userdata['role'] = 'student'
-            userdata['division'] = valid_school_code
+            user_data['validschool'] = True
+            user_data['role'] = 'student'
+            user_data['division'] = valid_school_code
 
         # Department Affiliations check
-        departmentaffiliation = person.get('departmentAffiliation', 'Not Available')
-        if departmentaffiliation.lower() != 'not available':
-            #userdata['departmentaffiliation'] = departmentaffiliation
-            valid_department = getvaliddept(departmentaffiliation)
+        department_affiliation = person.get('departmentAffiliation', 'Not Available')
+        if department_affiliation.lower() != 'not available':
+            valid_department = get_valid_dept(department_affiliation)
             if valid_department is not None:
-                userdata['validdept'] = True
-                userdata['role'] = 'employee'
-                userdata['division'] = valid_department
+                user_data['validdept'] = True
+                user_data['role'] = 'employee'
+                user_data['division'] = valid_department
 
-      
-    return userdata
+    return user_data

--- a/qualtrics_link/util.py
+++ b/qualtrics_link/util.py
@@ -192,7 +192,7 @@ def is_user_in_whitelist(huid):
 # we want to determine if any are employee status and to return that record.
 def filter_person_list(person_list):
     for person in person_list:
-        if person.role_type.lower() == 'employee':
+        if person.role_type_cd.lower() == 'employee':
             return person
     # If no employee records were found, then return the first person in the list
     return person_list[0]
@@ -200,7 +200,7 @@ def filter_person_list(person_list):
 
 # Get the person list matching the given HUID or return None
 def get_person_list(huid):
-    person_list = Person.objects.filter(huid=huid, prime_role_indicator='Y')
+    person_list = Person.objects.filter(univ_id=huid, prime_role_indicator='Y')
     return person_list
 
 

--- a/qualtrics_link/util.py
+++ b/qualtrics_link/util.py
@@ -206,16 +206,24 @@ def get_person_list(huid):
 
 
 # Will update the given HUID users current role and division for their Qualtrics account
-def update_user(huid, division, role):
+def update_qualtrics_user(huid, division, role):
     token = settings.QUALTRICS_LINK.get('QUALTRICS_API_TOKEN')
     req_params = {
         'divisionId': division,
         'userType': role
     }
 
-    requests.put(url='https://harvard.qualtrics.com/API/v3/users/:{}'.format(huid),
+    requests.put(url='https://harvard.qualtrics.com/API/v3/users/{}'.format(huid),
                  data=req_params,
                  headers={'X-API-TOKEN': token})
+
+
+# Query Qualtrics to get the user with the given HUID
+def get_qualtrics_user(huid):
+    token = settings.QUALTRICS_LINK.get('QUALTRICS_API_TOKEN')
+    response = requests.get(url='https://harvard.qualtrics.com/API/v3/users/{}'.format(huid),
+                            headers={'X-API-TOKEN': token})
+    return response
 
 
 # Maps the given school code to a school using the school_code_mapping table
@@ -227,6 +235,7 @@ def lookup_school_affiliations(school_cd):
         return 'Not Available'
 
 
+# Gets the list of school codes for each person in the given list
 def get_school_affiliations(person_list):
     affiliations = []
     for person in person_list:
@@ -255,7 +264,7 @@ class PersonDetails:
 
 
 # Creates a PersonDetails instance by using the given person record to get values for the extended fields
-def get_person_details(huid, request):
+def get_person_details(huid):
     person_list = get_person_list(huid)
 
     if len(person_list) > 0:

--- a/qualtrics_link/util.py
+++ b/qualtrics_link/util.py
@@ -222,7 +222,6 @@ def filter_person_list(person_list):
     # Employee check
     employee_list = []
     for person in person_list:
-        print person.role_type_cd
         if person.role_type_cd.lower() == 'employee':
             employee_list.append(person)
 

--- a/qualtrics_link/util.py
+++ b/qualtrics_link/util.py
@@ -110,7 +110,7 @@ def create_encoded_token(key_value_pairs):
     raw = pad(token)
     cipher = AES.new(key, AES.MODE_ECB)
     encoded_token = base64.b64encode(cipher.encrypt(raw))
-    return urllib2.quote(encoded_token.encode("utf8"),'')
+    return urllib2.quote(encoded_token.encode("utf8"), '')
 
 
 def get_sso_test_url(key_value_pairs):
@@ -136,6 +136,7 @@ def get_client_ip(request):
     return ip_address
 
 
+# Find the area for the given unit, if no matches then use 'Other'
 def lookup_unit(unit):
     if unit in AREA_LOOKUP:
         return AREA_LOOKUP[unit]
@@ -144,12 +145,12 @@ def lookup_unit(unit):
         return 'Other'
 
 
+# Determine If the given unit is contained in the Blacklist, if it is then it is not valid.
 def is_unit_valid(unit):
-    if unit not in BLACKLIST:
-        return True
-    return False
+    return unit not in BLACKLIST
 
 
+# Return the first school from the given school list that is not contained within the blacklist.
 def get_valid_school(schools):
     for school_code in schools:
         school = lookup_unit(school_code)
@@ -157,18 +158,19 @@ def get_valid_school(schools):
             return school
 
 
+# If department is not in the blacklist then return it's division, else return None
 def get_valid_dept(dept):
     division = lookup_unit(dept)
     if division not in BLACKLIST:
         return division
 
 
+# Determines if the Person with the given HUID is in the whitelist and the Person's expiration is today or greater.
 def is_user_in_whitelist(huid):
     try:
         person = QualtricsAccessList.objects.get(user_id=huid)
         if person.expiration_date:
-            expiration_date = person.expiration_date   
-            if expiration_date >= date.today():
+            if person.expiration_date >= date.today():
                 # the user is in the whitelist and has an expiration date that is valid
                 return True
             else:
@@ -179,6 +181,7 @@ def is_user_in_whitelist(huid):
             return True
     except QualtricsAccessList.DoesNotExist:
         # the user is not in the whitelist'
+        logger.info('The HUID {} does not exist within the Qualtrics access list.'.format(huid))
         return False
 
 

--- a/qualtrics_link/util.py
+++ b/qualtrics_link/util.py
@@ -232,7 +232,9 @@ def filter_person_list(person_list):
             return emp_with_prime
 
     # Check if any of the Person records contain the prime role indicator
-    get_person_with_prime_indicator(person_list)
+    person_with_prime = get_person_with_prime_indicator(person_list)
+    if person_with_prime is not None:
+        return person_with_prime
 
     # If no employee records were found, then return the first person in the list
     return person_list[0]

--- a/qualtrics_link/views.py
+++ b/qualtrics_link/views.py
@@ -1,12 +1,9 @@
-
-
 from django.shortcuts import render, redirect
 from django.views.decorators.http import require_http_methods
 import logging
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from icommons_common.monitor.views import BaseMonitorResponseView
-from icommons_common.models import QualtricsAccessList
 from icommons_common.icommonsapi import IcommonsApi
 from icommons_common.auth.decorators import group_membership_restriction
 from django.http import HttpResponse
@@ -14,17 +11,17 @@ from datetime import date
 import time
 import datetime
 import urllib
-import pprint
-import qualtrics_link.util
 from qualtrics_link.forms import SpoofForm
+import qualtrics_link.util as util
 
 logger = logging.getLogger(__name__)
+
 
 class MonitorResponseView(BaseMonitorResponseView):
     def healthy(self):
         return True
 
-#BLOCK_SIZE=16
+# BLOCK_SIZE=16
 BS = 16
 pad = lambda s: s + (BS - len(s) % BS) * chr(BS - len(s) % BS) 
 unpad = lambda s : s[0:-ord(s[-1])]
@@ -34,75 +31,66 @@ unpad = lambda s : s[0:-ord(s[-1])]
 def index(request):
     return render(request, 'qualtrics_link/index.html')
 
+
 @login_required
 @require_http_methods(['GET'])
 def launch(request):
 
-    validschool = False
-    validdepartment = False
-    userinwhitelist = False
-    usercanaccess = False
-    firstname = None
-    lastname = None
-    email = None
-    role = None
-    division = None
-    clientip = qualtrics_link.util.getclientip(request)
+    user_can_access = False
+    client_ip = util.get_client_ip(request)
 
     # get the expiration date in the correct format i.e. '2008-07-16T15:42:51' (date format is same as above)
     # In this case we take the current time and add 1 minutes (60 seconds)
-    currenttime = time.time()
-    currentdate = datetime.datetime.utcfromtimestamp(currenttime).strftime('%Y-%m-%dT%H:%M:%S')
+    current_time = time.time()
+    current_date = datetime.datetime.utcfromtimestamp(current_time).strftime('%Y-%m-%dT%H:%M:%S')
 
     # get the expiration date in the correct format i.e. '2008-07-16T15:42:51' (date format is same as above)
     # In this case we take the current time and add 5 minutes (300 seconds)
-    expirationdate = datetime.datetime.utcfromtimestamp(currenttime + 300).strftime('%Y-%m-%dT%H:%M:%S')
+    expiration_date = datetime.datetime.utcfromtimestamp(current_time + 300).strftime('%Y-%m-%dT%H:%M:%S')
 
     huid = request.user.username
-    userinwhitelist = qualtrics_link.util.isuserinwhitelist(huid)
+    user_in_whitelist = util.is_user_in_whitelist(huid)
 
     # make sure this is an HUID
-    if not huid.isdigit() and not userinwhitelist:
-        logline = "xidnotauthorized\t{}\t{}".format(currentdate, clientip)
-        logger.info(logline)
+    if not huid.isdigit() and not user_in_whitelist:
+        logger.info("xidnotauthorized\t{}\t{}".format(current_date, client_ip))
         return render(request, 'qualtrics_link/notauthorized.html', {'request': request})
     
-    persondataobj = IcommonsApi()
-    resp = persondataobj.people_by_id(huid)
+    person_data_obj = IcommonsApi()
+    resp = person_data_obj.people_by_id(huid)
 
     if resp.status_code == 200:
         data = resp.json()
-        userdict = qualtrics_link.util.builduserdict(data)
-        firstname = userdict.get('firstname')
-        lastname = userdict.get('lastname')
-        email = userdict.get('email')
-        role = userdict.get('role')
-        division = userdict.get('division')
-        validschool = userdict.get('validschool', False)
-        validdepartment = userdict.get('validdept', False)
+        user_dict = util.build_user_dict(data)
+        first_name = user_dict.get('firstname')
+        last_name = user_dict.get('lastname')
+        email = user_dict.get('email')
+        role = user_dict.get('role')
+        division = user_dict.get('division')
+        valid_school = user_dict.get('validschool', False)
+        valid_department = user_dict.get('validdept', False)
 
     else:
         logmsg = 'huid: {}, api call returned response code {}'.format(huid, str(resp.status_code))
         logger.error(logmsg)
         return render(request, 'qualtrics_link/error.html', {'request': request})
 
- 
-    # check if the user can use qualtrics or not
+    # Check if the user can use qualtrics or not
     # the value of usercanaccess is set to False by default
     # if any of the checks here pass we set usercanaccess to True
-    if validdepartment or validschool or userinwhitelist:
-        usercanaccess = True
+    if valid_department or valid_school or user_in_whitelist:
+        user_can_access = True
 
-    if usercanaccess:
-        #Check to see if the user has accepted the terms of service    
-        agreementid = settings.QUALTRICS_LINK.get('AGREEMENT_ID', '260')
-        acceptance_resp = persondataobj.tos_get_acceptance(agreementid, huid)
+    if user_can_access:
+        # Check to see if the user has accepted the terms of service
+        agreement_id = settings.QUALTRICS_LINK.get('AGREEMENT_ID', '260')
+        acceptance_resp = person_data_obj.tos_get_acceptance(agreement_id, huid)
         
         if acceptance_resp.status_code == 200:
             acceptance_json = acceptance_resp.json()
             if 'agreements' in acceptance_json:
-                lenth = len(acceptance_json['agreements'])
-                if lenth > 0:
+                length = len(acceptance_json['agreements'])
+                if length > 0:
                     acceptance_text = acceptance_json['agreements'][0]['text']
                     return render(request, 'qualtrics_link/agreement.html', {'request': request, 'agreement' : acceptance_text})
             else:
@@ -114,17 +102,17 @@ def launch(request):
             logger.error(logmsg)
             return render(request, 'qualtrics_link/error.html', {'request': request})
 
-        enc_id = qualtrics_link.util.getencryptedhuid(huid)
-        keyvaluepairs = "id="+enc_id+"&timestamp="+currentdate+"&expiration="+expirationdate+"&firstname="+firstname+"&lastname="+lastname+"&email="+email+"&UserType="+role+"&Division="+division
-        qualtricslink = qualtrics_link.util.getqualtricsurl(keyvaluepairs) 
-        logline = "{}\t{}\t{}\t{}".format(currentdate, clientip, role, division)
+        enc_id = util.get_encrypted_huid(huid)
+        key_value_pairs = "id="+enc_id+"&timestamp="+current_date+"&expiration="+expiration_date+"&firstname="+first_name+"&lastname="+last_name+"&email="+email+"&UserType="+role+"&Division="+division
+        qualtrics_link = util.getqualtrics_url(key_value_pairs)
+        logline = "{}\t{}\t{}\t{}".format(current_date, client_ip, role, division)
         logger.info(logline)
 
-        #the redirect line below will be how the application works if everything is good for the user. 
-        return redirect(qualtricslink)
+        # The redirect line below will be how the application works if everything is good for the user.
+        return redirect(qualtrics_link)
 
     else:
-        logline = "notauthorized\t{}\t{}\t{}\t{}".format(currentdate, clientip, role, division)
+        logline = "notauthorized\t{}\t{}\t{}\t{}".format(current_date, client_ip, role, division)
         logger.info(logline)
         return render(request, 'qualtrics_link/notauthorized.html', {'request': request})
 
@@ -143,203 +131,180 @@ def internal(request):
     email = None
     role = None
     division = None
-    clientip = qualtrics_link.util.getclientip(request)
+    client_ip = util.get_client_ip(request)
 
     # get the current date in the correct format i.e. '2008-07-16T15:42:51'
-    currenttime = time.time()
-    currentdate = datetime.datetime.utcfromtimestamp(currenttime).strftime('%Y-%m-%dT%H:%M:%S')
+    current_time = time.time()
+    current_date = datetime.datetime.utcfromtimestamp(current_time).strftime('%Y-%m-%dT%H:%M:%S')
 
     # get the expiration date in the correct format i.e. '2008-07-16T15:42:51' (date format is same as above)
     # In this case we take the current time and add 10 minutes (600 seconds)
-    expirationdate = datetime.datetime.utcfromtimestamp(currenttime + 600).strftime('%Y-%m-%dT%H:%M:%S')
+    expiration_date = datetime.datetime.utcfromtimestamp(current_time + 600).strftime('%Y-%m-%dT%H:%M:%S')
 
- 
     # Form to allow admins to spoof other users
     if 'huid' in request.GET: # If the form has been submitted...
         # ContactForm was defined in the the previous section
-        spoofform = SpoofForm(request.GET) # A form bound to the POST data
-        if spoofform.is_valid(): # All validation rules pass
+        spoof_form = SpoofForm(request.GET) # A form bound to the POST data
+        if spoof_form.is_valid(): # All validation rules pass
             huid = request.GET['huid']
             huid = huid.strip()
-            logger.info('USER: '+str(request.user.username)+ ' Spoofing: ' +huid)
+            logger.info('USER: '+str(request.user.username) + ' Spoofing: ' + huid)
             if huid == '':
                 if 'spoofid' in request.session:
                     del request.session['spoofid']
                 huid = request.user.username
                 
     elif 'spoofid' in request.session:
-        # we got here becuase the user accepted the tos and we needed a way to stay the spoofed user
+        # we got here because the user accepted the tos and we needed a way to stay the spoofed user
         huid = request.session.get('spoofid')
         huid = huid.strip()
-        logger.info('USER: '+str(request.user.username)+ ' Spoofing: ' +str(request.session.get('spoofid', 'None')))
-        spoofform = SpoofForm({'huid' : huid.strip()})
+        logger.info('USER: ' + str(request.user.username) + ' Spoofing: ' + str(request.session.get('spoofid', 'None')))
+        spoof_form = SpoofForm({'huid': huid.strip()})
     else:
-        spoofform = SpoofForm() # An unbound form
+        spoof_form = SpoofForm() # An unbound form
         huid = request.user.username
         huid = huid.strip()
 
-    userinwhitelist = qualtrics_link.util.isuserinwhitelist(huid)
+    user_in_whitelist = util.is_user_in_whitelist(huid)
 
     if not huid.isdigit() and not userinwhitelist:
-        logline = "xidnotauthorized\t{}\t{}".format(currentdate, clientip)
+        logline = "xidnotauthorized\t{}\t{}".format(current_date, client_ip)
         logger.info(logline)
         return render(request, 'qualtrics_link/notauthorized.html', {'request': request})
 
     # initialize the icommons api module
-    persondataobj = IcommonsApi()
-    person = persondataobj.people_by_id(huid)
+    person_data_obj = IcommonsApi()
+    person = person_data_obj.people_by_id(huid)
 
     if person.status_code == 200:
         data = person.json()
         user = data['people'][0]
-        userdict = qualtrics_link.util.builduserdict(data)
-        firstname = userdict.get('firstname')
-        lastname = userdict.get('lastname')
-        email = userdict.get('email')
-        role = userdict.get('role')
-        division = userdict.get('division')
-        validschool = userdict.get('validschool', False)
-        validdepartment = userdict.get('validdept', False)
-        #userdict['currenttime'] = currentdate
-        #userdict['expirationtime'] = expirationdate
+        user_dict = util.builduserdict(data)
+        first_name = user_dict.get('firstname')
+        last_name = user_dict.get('lastname')
+        email = user_dict.get('email')
+        role = user_dict.get('role')
+        division = user_dict.get('division')
+        valid_school = user_dict.get('validschool', False)
+        valid_department = user_dict.get('validdept', False)
 
     else:
         logmsg = 'huid: {}, api call returned response code {}'.format(huid, str(person.status_code))
         logger.error(logmsg)
         return render(request, 'qualtrics_link/error.html', {'request': request})
 
+    # Check if the user can use qualtrics or not
+    # the value of user_can_access is set to False by default
+    # if any of the checks here pass we set user_can_access to True
+    if valid_department or valid_school or user_in_whitelist:
+        user_can_access = True
     
- 
-    # check if the user can use qualtrics or not
-    # the value of usercanaccess is set to False by default
-    # if any of the checks here pass we set usercanaccess to True
-    if validdepartment or validschool or userinwhitelist:
-        usercanaccess = True
-    
-    if usercanaccess:
+    if user_can_access:
         # If they are allowed to use Qualtrics, check to see if the user has accepted the terms of service    
-        agreementid = settings.QUALTRICS_LINK.get('AGREEMENT_ID')
-        acceptance_resp = persondataobj.tos_get_acceptance(agreementid, huid)
+        agreement_id = settings.QUALTRICS_LINK.get('AGREEMENT_ID')
+        acceptance_resp = person_data_obj.tos_get_acceptance(agreement_id, huid)
         
         if acceptance_resp.status_code == 200:
             acceptance_json = acceptance_resp.json()
             if 'agreements' in acceptance_json:
-                lenth = len(acceptance_json['agreements'])
-                if lenth > 0:
+                length = len(acceptance_json['agreements'])
+                if length > 0:
                     acceptance_text = acceptance_json['agreements'][0]['text']
                     request.session['spoofid'] = huid
-                    return render(request, 'qualtrics_link/agreement.html', {'request': request, 'agreement' : acceptance_text})
+                    return render(request, 'qualtrics_link/agreement.html', {'request': request, 'agreement': acceptance_text})
             else:
-                logmsg = 'huid: {}, api call returned response code {}'.format(huid, str(person.status_code))
-                logger.error(logmsg)
+                logger.error('huid: {}, api call returned response code {}'.format(huid, str(person.status_code)))
                 return render(request, 'qualtrics_link/error.html', {'request': request})
         else:
-            logmsg = 'huid: {}, api call returned response code {}'.format(huid, str(person.status_code))
-            logger.error(logmsg)
+            logger.error('huid: {}, api call returned response code {}'.format(huid, str(person.status_code)))
             return render(request, 'qualtrics_link/error.html', {'request': request})
 
-        enc_id = qualtrics_link.util.getencryptedhuid(huid)
-        logline = "{}\t{}\t{}\t{}".format(currentdate, clientip, role, division)
+        enc_id = util.getencryptedhuid(huid)
+        logline = "{}\t{}\t{}\t{}".format(current_date, client_ip, role, division)
         logger.info(logline)
-        keyvaluepairs = "id="+enc_id+"&timestamp="+currentdate+"&expiration="+expirationdate+"&firstname="+firstname+"&lastname="+lastname+"&email="+email+"&UserType="+role+"&Division="+division
-        ssotestlink = qualtrics_link.util.getssotesturl(keyvaluepairs)
-        qualtricslink = qualtrics_link.util.getqualtricsurl(keyvaluepairs) #'https://harvard.qualtrics.com/ControlPanel/?ssotoken='+encodedtoken
-        return render(request, 'qualtrics_link/main.html', {'request': request, 'qualtricslink' : qualtricslink, 'ssotestlink': ssotestlink, 'huid' : huid, 'user_in_whitelist' : userinwhitelist, 'keyValueDict' :  userdict, 'person' : user, 'form' : spoofform})
+        key_value_pairs = "id="+enc_id+"&timestamp="+current_date+"&expiration="+expiration_date+"&firstname="+first_name+"&lastname="+last_name+"&email="+email+"&UserType="+role+"&Division="+division
+        sso_test_link = util.get_sso_test_url(key_value_pairs)
+        qualtrics_link = util.get_qualtrics_url(key_value_pairs)
+        return render(request, 'qualtrics_link/main.html', {'request': request, 'qualtricslink' : qualtrics_link, 'ssotestlink': sso_test_link, 'huid': huid, 'user_in_whitelist': user_in_whitelist, 'keyValueDict':  user_dict, 'person': user, 'form': spoof_form})
         
     else:
-        logline = "notauthorized\t{}\t{}\t{}\t{}".format(currentdate, clientip, role, division)
+        logline = "notauthorized\t{}\t{}\t{}\t{}".format(current_date, client_ip, role, division)
         logger.info(logline)
-        return render(request, 'qualtrics_link/notauthinternal.html', {'request': request, 'person' : user, 'processeddata' : userdict})
+        return render(request, 'qualtrics_link/notauthinternal.html', {'request': request, 'person': user, 'processeddata' : user_dict})
 
 @login_required
 @require_http_methods(['GET'])
 def user_accept_terms(request):
-    
-    # this is handy for debugging the post request
-    #import httplib
-    #httplib.HTTPConnection.debuglevel = 1
-
     huid = request.session.get('spoofid', False)
     if not huid:
         huid = request.user.username
 
-    persondataobj = IcommonsApi()
-    ipaddress = qualtrics_link.util.getclientip(request)
-    params = {'agreementId' : '260', 'ipAddress' : ipaddress,}
-    resp = persondataobj.tos_create_acceptance(params, huid)
+    person_data_obj = IcommonsApi()
+    ip_address = util.get_client_ip(request)
+    params = {'agreementId': '260', 'ipAddress': ip_address}
+    resp = person_data_obj.tos_create_acceptance(params, huid)
     
     if resp.status_code == 200:
-        logline = "termsofservice accepted: \t{}\t{}".format(ipaddress, '260')
-        logger.info(logline)
+        logger.info("termsofservice accepted: \t{}\t{}".format(ip_address, '260'))
         return redirect(settings.QUALTRICS_LINK.get('USER_ACCEPTED_TERMS_URL', 'ql:launch'))
     
-    logline = "Error accepting terms of service"
-    logger.error(logline)
+    logger.error("Error accepting terms of service")
     return render(request, 'qualtrics_link/error.html', {'request': request})
     
 
 @login_required
 @require_http_methods(['GET'])
 def user_decline_terms(request):
-
-    logline = "User decliend terms of service"
-    logger.info(logline)
+    logger.info("User declined terms of service")
     return redirect(settings.QUALTRICS_LINK.get('USER_DECLINED_TERMS_URL', 'http://surveytools.harvard.edu'))
 
 
 @require_http_methods(['GET'])
 def get_org_info(request):
 
-    apiurl = settings.QUALTRICS_LINK.get('QUALTRICS_API_URL')
-    enddate = date.today().strftime("%Y-%m-%d")
-
-    #pp = pprint.PrettyPrinter(indent=4)
+    api_url = settings.QUALTRICS_LINK.get('QUALTRICS_API_URL')
+    end_date = date.today().strftime("%Y-%m-%d")
 
     query = {
         'Request' : 'getResponseCountsByOrganization',
         'User' : settings.QUALTRICS_LINK.get('QUALTRICS_API_USER'),
         'Token' : settings.QUALTRICS_LINK.get('QUALTRICS_API_TOKEN'),
         'StartDate' : '2010-01-01',
-        'EndDate' : enddate,
+        'EndDate' : end_date,
         'Format' : 'JSON',
         'Version' : '2.0',
     }
 
     if 'getResponseCountsByOrganization' not in request.session:
         params = urllib.urlencode(query)
-        apiresponse = urllib.urlopen(apiurl, params)
-        result = apiresponse.read()
+        api_response = urllib.urlopen(api_url, params)
+        result = api_response.read()
         request.session['getResponseCountsByOrganization'] = result
     else:
         result = request.session.get('getResponseCountsByOrganization', '{}')
 
-    #pp.pprint(result)
-
-    responsecounts = '{ "getResponseCountsByOrganization" : '+result+ '}'
-    apiresponse = None
-    result = None
+    response_counts = '{ "getResponseCountsByOrganization" : ' + result + '}'
+    api_response = None
 
     query2 = {
-        'Request' : 'getOrgActivity',
-        'User' : settings.QUALTRICS_LINK.get('QUALTRICS_API_USER'),
-        'Token' : settings.QUALTRICS_LINK.get('QUALTRICS_API_TOKEN'),
-        'Format' : 'JSON',
-        'Version' : '2.0',
-        'Organization' : 'harvard', 
+        'Request': 'getOrgActivity',
+        'User': settings.QUALTRICS_LINK.get('QUALTRICS_API_USER'),
+        'Token': settings.QUALTRICS_LINK.get('QUALTRICS_API_TOKEN'),
+        'Format': 'JSON',
+        'Version': '2.0',
+        'Organization': 'harvard',
     }
 
     if 'getOrgActivity' not in request.session:
         params = urllib.urlencode(query2)
-        apiresponse = urllib.urlopen(apiurl, params)
-        result = apiresponse.read()
+        api_response = urllib.urlopen(api_url, params)
+        result = api_response.read()
         request.session['getOrgActivity'] = result
     else:
         result = request.session.get('getOrgActivity', '{}')
 
-    #pp.pprint(result)
-
-    orgactivity = '{ "getOrgActivity" : '+result+ '}'
-    result = '{ "org_info" : ['+responsecounts+ ','+orgactivity+' ]}'
+    org_activity = '{ "getOrgActivity" : '+result+ '}'
+    result = '{ "org_info" : [' + response_counts + ',' + org_activity + ' ]}'
 
     response = HttpResponse(result, content_type="application/json")
     response["Access-Control-Allow-Origin"] = "*" 

--- a/qualtrics_link/views.py
+++ b/qualtrics_link/views.py
@@ -1,20 +1,20 @@
-from django.shortcuts import render, redirect
-from django.views.decorators.http import require_http_methods
+import datetime
 import logging
+import time
+import urllib
+from datetime import date
+
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from icommons_common.monitor.views import BaseMonitorResponseView
-from icommons_common.icommonsapi import IcommonsApi
-from icommons_common.auth.decorators import group_membership_restriction
 from django.http import HttpResponse
-from datetime import date
-import time
-import datetime
-import urllib
-from qualtrics_link.forms import SpoofForm
+from django.shortcuts import render, redirect
+from django.views.decorators.http import require_http_methods
+
 import qualtrics_link.util as util
-from django.conf import settings
-import requests
+from icommons_common.auth.decorators import group_membership_restriction
+from icommons_common.icommonsapi import IcommonsApi
+from icommons_common.monitor.views import BaseMonitorResponseView
+from qualtrics_link.forms import SpoofForm
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +162,7 @@ def internal(request):
     person_details = util.get_person_details(huid)
 
     if person_details is None:
-        logger.error('No records with the huid of {} could be found').format(huid)
+        logger.error('No records with the huid of {} could be found'.format(huid))
         return render(request, 'qualtrics_link/error.html', {'request': request})
 
     icommons_api = IcommonsApi()

--- a/qualtrics_link/views.py
+++ b/qualtrics_link/views.py
@@ -90,9 +90,9 @@ def launch(request):
         key_value_pairs = key_value_pairs.format(enc_id,
                                                  current_date,
                                                  expiration_date,
-                                                 person_details.name_first,
-                                                 person_details.name_last,
-                                                 person_details.email_address,
+                                                 person_details.first_name,
+                                                 person_details.last_name,
+                                                 person_details.email,
                                                  person_details.role,
                                                  person_details.division)
         qualtrics_link = util.get_qualtrics_url(key_value_pairs)
@@ -169,9 +169,9 @@ def internal(request):
     
     if user_can_access:
         # If they are allowed to use Qualtrics, check to see if the user has accepted the terms of service    
-        agreement_id = settings.QUALTRICS_LINK.get('AGREEMENT_ID')
+        agreement_id = settings.QUALTRICS_LINK.get('AGREEMENT_ID', '260')
         acceptance_resp = icommons_api.tos_get_acceptance(agreement_id, huid)
-        
+
         if acceptance_resp.status_code == 200:
             acceptance_json = acceptance_resp.json()
             if 'agreements' in acceptance_json:
@@ -184,19 +184,19 @@ def internal(request):
                 logger.error('Received acceptance status of 200 but could not find any agreements for huid: {}'.format(huid))
                 return render(request, 'qualtrics_link/error.html', {'request': request})
         else:
-            logger.error('huid: {}, api call returned response code other than 200 {}'.format(acceptance_resp))
+            logger.error('huid: {}, api call returned response code other than 200 {}'.format(huid, acceptance_resp))
             return render(request, 'qualtrics_link/error.html', {'request': request})
 
         enc_id = util.get_encrypted_huid(huid)
         logline = "{}\t{}\t{}\t{}".format(current_date, client_ip, person_details.role, person_details.division)
         logger.info(logline)
-        key_value_pairs = "id={}&timestamp={}&expiration={}&firstname={}&lastname={}&email={}&UserType={}&Division={}"
+        key_value_pairs = u"id={}&timestamp={}&expiration={}&firstname={}&lastname={}&email={}&UserType={}&Division={}"
         key_value_pairs = key_value_pairs.format(enc_id,
                                                  current_date,
                                                  expiration_date,
-                                                 person_details.name_first,
-                                                 person_details.name_last,
-                                                 person_details.email_address,
+                                                 person_details.first_name,
+                                                 person_details.last_name,
+                                                 person_details.email,
                                                  person_details.role,
                                                  person_details.division)
         sso_test_link = util.get_sso_test_url(key_value_pairs)

--- a/qualtrics_link/views.py
+++ b/qualtrics_link/views.py
@@ -13,8 +13,6 @@ import datetime
 import urllib
 from qualtrics_link.forms import SpoofForm
 import qualtrics_link.util as util
-import requests
-from icommons_common.models import Person
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -59,9 +57,8 @@ def launch(request):
         logger.info("xidnotauthorized\t{}\t{}".format(current_date, client_ip))
         return render(request, 'qualtrics_link/notauthorized.html', {'request': request})
     
-    person = util.get_correct_person(huid, request)
     # The PersonDetails object extends the Person model with additional attributes
-    person_details = util.get_person_details(person)
+    person_details = util.get_person_details(huid, request)
 
     # Check if the user can use qualtrics or not
     # the value of user_can_access is set to False by default
@@ -100,6 +97,9 @@ def launch(request):
                                                  person_details.division)
         qualtrics_link = util.get_qualtrics_url(key_value_pairs)
         logger.info("{}\t{}\t{}\t{}".format(current_date, client_ip, person_details.role, person_details.division))
+
+        # Update the users division and role fields of their Qualtrics profile
+        util.update_user(huid, person_details.division, person_details.role)
 
         # The redirect line below will be how the application works if everything is good for the user.
         return redirect(qualtrics_link)
@@ -156,36 +156,24 @@ def internal(request):
         logger.info("xidnotauthorized\t{}\t{}".format(current_date, client_ip))
         return render(request, 'qualtrics_link/notauthorized.html', {'request': request})
 
-    # initialize the icommons api module
-    person_data_obj = IcommonsApi()
-    person = person_data_obj.people_by_id(huid)
+        # The PersonDetails object extends the Person model with additional attributes
+        person_details = util.get_person_details(person)
 
-    if person.status_code == 200:
-        data = person.json()
-        user = data['people'][0]
-        user_dict = util.build_user_dict(data)
-        first_name = user_dict.get('firstname')
-        last_name = user_dict.get('lastname')
-        email = user_dict.get('email')
-        role = user_dict.get('role')
-        division = user_dict.get('division')
-        valid_school = user_dict.get('validschool', False)
-        valid_department = user_dict.get('validdept', False)
+        icommons_api = IcommonsApi()
 
     else:
-        logger.error('huid: {}, api call returned response code {}'.format(huid, str(person.status_code)))
         return render(request, 'qualtrics_link/error.html', {'request': request})
 
     # Check if the user can use qualtrics or not
     # the value of user_can_access is set to False by default
     # if any of the checks here pass we set user_can_access to True
-    if valid_department or valid_school or user_in_whitelist:
+    if person_details.valid_department or person_details.valid_school or user_in_whitelist:
         user_can_access = True
     
     if user_can_access:
         # If they are allowed to use Qualtrics, check to see if the user has accepted the terms of service    
         agreement_id = settings.QUALTRICS_LINK.get('AGREEMENT_ID')
-        acceptance_resp = person_data_obj.tos_get_acceptance(agreement_id, huid)
+        acceptance_resp = icommons_api.tos_get_acceptance(agreement_id, huid)
         
         if acceptance_resp.status_code == 200:
             acceptance_json = acceptance_resp.json()
@@ -205,14 +193,32 @@ def internal(request):
         enc_id = util.get_encrypted_huid(huid)
         logline = "{}\t{}\t{}\t{}".format(current_date, client_ip, role, division)
         logger.info(logline)
-        key_value_pairs = "id="+enc_id+"&timestamp="+current_date+"&expiration="+expiration_date+"&firstname="+first_name+"&lastname="+last_name+"&email="+email+"&UserType="+role+"&Division="+division
+        key_value_pairs = "id={}&timestamp={}&expiration={}&firstname={}&lastname={}&email={}&UserType={}&Division={}"
+        key_value_pairs = key_value_pairs.format(enc_id,
+                                                 current_date,
+                                                 expiration_date,
+                                                 person_details.name_first,
+                                                 person_details.name_last,
+                                                 person_details.email_address,
+                                                 person_details.role,
+                                                 person_details.division)
         sso_test_link = util.get_sso_test_url(key_value_pairs)
         qualtrics_link = util.get_qualtrics_url(key_value_pairs)
-        return render(request, 'qualtrics_link/main.html', {'request': request, 'qualtricslink' : qualtrics_link, 'ssotestlink': sso_test_link, 'huid': huid, 'user_in_whitelist': user_in_whitelist, 'keyValueDict':  user_dict, 'person': user, 'form': spoof_form})
+        context = {
+            'request': request,
+            'qualtricslink': qualtrics_link,
+            'ssotestlink': sso_test_link,
+            'huid': huid,
+            'user_in_whitelist': user_in_whitelist,
+            'processed_data': person_details,
+            'person': person_details.person,
+            'form': spoof_form
+        }
+        return render(request, 'qualtrics_link/main.html', context)
         
     else:
         logger.info("notauthorized\t{}\t{}\t{}\t{}".format(current_date, client_ip, role, division))
-        return render(request, 'qualtrics_link/notauthinternal.html', {'request': request, 'person': user, 'processeddata' : user_dict})
+        return render(request, 'qualtrics_link/notauthinternal.html', {'request': request, 'person': person_details.person, 'processed_data': person_details})
 
 
 @login_required
@@ -222,10 +228,10 @@ def user_accept_terms(request):
     if not huid:
         huid = request.user.username
 
-    person_data_obj = IcommonsApi()
+    icommons_api = IcommonsApi()
     ip_address = util.get_client_ip(request)
     params = {'agreementId': '260', 'ipAddress': ip_address}
-    resp = person_data_obj.tos_create_acceptance(params, huid)
+    resp = icommons_api.tos_create_acceptance(params, huid)
     
     if resp.status_code == 200:
         logger.info("termsofservice accepted: \t{}\t{}".format(ip_address, '260'))
@@ -286,7 +292,7 @@ def get_org_info(request):
     else:
         result = request.session.get('getOrgActivity', '{}')
 
-    org_activity = '{ "getOrgActivity" : '+result+ '}'
+    org_activity = '{ "getOrgActivity" : ' + result + '}'
     result = '{ "org_info" : [' + response_counts + ',' + org_activity + ' ]}'
 
     response = HttpResponse(result, content_type="application/json")

--- a/qualtrics_link/views.py
+++ b/qualtrics_link/views.py
@@ -104,7 +104,7 @@ def launch(request):
         logger.info("{}\t{}\t{}\t{}".format(current_date, client_ip, person_details.role, person_details.division))
 
         # We only want to call the update function if there is an account, check to see if one exists
-        if util.get_qualtrics_user(huid).status_code != requests.requests.codes.ok:
+        if util.get_qualtrics_user(huid).status_code == requests.requests.codes.ok:
             # Update the users division and role fields of their Qualtrics profile
             util.update_qualtrics_user(huid, person_details.division, person_details.role)
 

--- a/qualtrics_link/views.py
+++ b/qualtrics_link/views.py
@@ -91,7 +91,7 @@ def launch(request):
             return render(request, 'qualtrics_link/error.html', {'request': request})
 
         enc_id = util.get_encrypted_huid(huid)
-        key_value_pairs = "id={}&timestamp={}&expiration={}&firstname={}&lastname={}&email={}&UserType={}&Division={}"
+        key_value_pairs = u"id={}&timestamp={}&expiration={}&firstname={}&lastname={}&email={}&UserType={}&Division={}"
         key_value_pairs = key_value_pairs.format(enc_id,
                                                  current_date,
                                                  expiration_date,
@@ -102,11 +102,6 @@ def launch(request):
                                                  person_details.division)
         qualtrics_link = util.get_qualtrics_url(key_value_pairs)
         logger.info("{}\t{}\t{}\t{}".format(current_date, client_ip, person_details.role, person_details.division))
-
-        # We only want to call the update function if there is an account, check to see if one exists
-        if util.get_qualtrics_user(huid).status_code == requests.requests.codes.ok:
-            # Update the users division and role fields of their Qualtrics profile
-            util.update_qualtrics_user(huid, person_details.division, person_details.role)
 
         # The redirect line below will be how the application works if everything is good for the user.
         return redirect(qualtrics_link)


### PR DESCRIPTION
[TLT-2838](https://jira.huit.harvard.edu/browse/TLT-2838)

When a new Qualtrics user is created, they should have the role of either 'Employee' or 'Student' and their Division should reflect their affiliation. 
This fixes the issue where a user could have the role of 'generic' and their division was either set incorrectly or not set at all.