### PR TITLE
A null field in oracle returns an empty string not a None object

### DIFF
--- a/qualtrics_link/util.py
+++ b/qualtrics_link/util.py
@@ -356,7 +356,7 @@ def get_person_details(huid):
         division = valid_school_code
 
     # Department Affiliations check
-    if person.department is not None:
+    if person.department != '':
         valid_dept_name = get_valid_dept(person.department)
         if valid_dept_name is not None:
             valid_dept = True


### PR DESCRIPTION
Will fix when a record is returned with a null department and keep the default student role and set the division as Other