### PR TITLE
Task/sapnamysre/tlt 3176/add acceptance tables

### DIFF
--- a/icommons_ext_tools/settings/base.py
+++ b/icommons_ext_tools/settings/base.py
@@ -227,7 +227,7 @@ LOGGING = {
             'class': 'logging.handlers.WatchedFileHandler',
             'level': _DEFAULT_LOG_LEVEL,
             'formatter': 'verbose',
-            'filename': os.path.normpath(os.path.join(_LOG_ROOT, 'django-icommons_ext_tools.log')),
+            'filename': os.path.join(_LOG_ROOT, 'django-icommons_ext_tools.log'),
         },
         'console': {
             'level': _DEFAULT_LOG_LEVEL,
@@ -258,6 +258,11 @@ LOGGING = {
             'handlers': ['console', 'default'],
             'propagate': False,
         },
+        'icommons_common': {
+            'handlers': ['console', 'default'],
+            'level': _DEFAULT_LOG_LEVEL,
+            'propagate': False,
+        },
     }
 }
 
@@ -276,6 +281,6 @@ QUALTRICS_LINK = {
     'QUALTRICS_API_USER': SECURE_SETTINGS.get('qualtrics_api_user'),
     'QUALTRICS_API_TOKEN': SECURE_SETTINGS.get('qualtrics_api_token'),
     'QUALTRICS_AUTH_GROUP': SECURE_SETTINGS.get('qualtrics_auth_group'),
-    'USER_DECLINED_TERMS_URL': SECURE_SETTINGS.get('qualtrics_user_declined_terms_url'),
+    'USER_DECLINED_TERMS_URL': SECURE_SETTINGS.get('qualtrics_user_declined_terms_url','http://surveytools.harvard.edu'),
     'USER_ACCEPTED_TERMS_URL': SECURE_SETTINGS.get('qualtrics_user_accepted_terms_url'),
 }

--- a/icommons_ext_tools/settings/base.py
+++ b/icommons_ext_tools/settings/base.py
@@ -268,11 +268,6 @@ LOGGING = {
 
 # Other app specific settings
 
-ICOMMONS_COMMON = {
-    'ICOMMONS_API_HOST': SECURE_SETTINGS.get('icommons_api_host'),
-    'ICOMMONS_API_USER': SECURE_SETTINGS.get('icommons_api_user'),
-    'ICOMMONS_API_PASS': SECURE_SETTINGS.get('icommons_api_pass'),
-}
 
 QUALTRICS_LINK = {
     'AGREEMENT_ID': SECURE_SETTINGS.get('qualtrics_agreement_id'),

--- a/qualtrics_link/migrations/0002_add_acceptance.py
+++ b/qualtrics_link/migrations/0002_add_acceptance.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models, transaction
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('qualtrics_link', '0001_initial'),
+    ]
+
+    user_id = models.CharField(max_length=200)
+    acceptance_date = models.DateTimeField()
+    ip_address = models.CharField(max_length=100)
+
+    operations = [
+         migrations.CreateModel(
+            name='Acceptance',
+            fields=[
+                ('user_id', models.CharField(max_length=30, primary_key=True)),
+                ('acceptance_date', models.DateTimeField(auto_now_add=True)),
+                ('ip_address', models.CharField(max_length=100)),
+            ],
+            options={
+                'db_table': 'acceptance',
+            },
+         )
+    ]
+

--- a/qualtrics_link/models.py
+++ b/qualtrics_link/models.py
@@ -24,3 +24,18 @@ class SchoolCodeMapping(models.Model):
     def __unicode__(self):
         return self.student_school_code
 
+class Acceptance(models.Model):
+    """
+    This is a table used to track and store Qulatrics user acceptance of terms
+    of service
+    """
+    user_id = models.CharField(max_length=200, primary_key=True)
+    acceptance_date = models.DateTimeField()
+    ip_address = models.CharField(max_length=100)
+
+    class Meta:
+        db_table = u'acceptance'
+
+    def __unicode__(self):
+        return self.id
+

--- a/qualtrics_link/templates/qualtrics_link/agreement.html
+++ b/qualtrics_link/templates/qualtrics_link/agreement.html
@@ -7,7 +7,38 @@
 	<h2>Qualtrics Agreement</h2>
 
 
-{{agreement|safe}}
+    <p>The Qualtrics survey tool is available for use by Harvard faculty, staff, and students in support of the university's educational mission and organizational goals.  By using Qualtrics you are agreeing to adhere to the following terms:
+    </p>
+    <label for="agree1">Appropriate Use</label>
+    <ul id="agree1">
+
+    <li>No High Risk Confidential Information
+    University policies prohibit the use of Qualtirics for "high-risk, confidential information," or HRCI. For a definition of HRCI, please see http://www.security.harvard.edu/glossary-terms.  For Harvard security policies, please see, http://ww.security.harvard.edu. For research data security policies, please see: http://security.harvard.edu/focus-research.
+    </li>
+    <li>Human Subject Research Must Be Approved by an IRB
+    In accordance with federal regulations and Harvard University policies, all research involving human subjects must be reviewed and approved by an Institutional Review Board (IRB) prior to any research intervention with a participant. Please visit the Web site for the Harvard Office of the Vice Provost for Research for more information: http://vpr.harvard.edu/. You are responsible for ensuring compliance with federal regulations and Harvard research policies.
+    </li>
+    <li>Protecting Privacy
+    All surveys must protect the privacy and confidentiality of student, employee and other institutional information, as required by FERPA (privacy of student information), appropriate state laws, and Harvard policies.  Although a closed group of participants may complete Qualtrics surveys without the individuals explicitly having to identify themselves, the Qualitrics software stores identifying information in its databases. Consequently, Qualtrics can not be used with absolute guarantees of anonymity for your participants.
+    </li>
+    <li>Compliance with all other  Laws ad Policies
+    Surveys must comply with all other applicable University policies and state and federal laws, including the federal [http://www.copyright.gov/help/faq]   [http://www.copyright.gov/help/faq] laws  for copyright [http://www.copyright.gov/help/faq]   [http://www.copyright.gov/help/faq]  and privacy.
+    </li>
+    <li>The survey service may not be used for personal or commercial gain</li>
+    <li>Unsolicited mass communication may not be delivered in conjunction with the survey service</li>
+    <li>Survey participants should be informed that their survey data will be stored on a third party server and that, while the third party has agreed to keep the data confidential, Harvard does not control the security of that server.
+    </li>
+    </ul>
+    <p>
+    The Office of the University CIO reserves the right to change, at any time, and at its sole discretion, this survey service and these Terms of Use. Notification of changes will be published at http://survey.harvard.edu.
+    </p>
+    <p>
+    I understand that The Harvard Qualtrics survey tool may not be used to store or process high-risk, confidential information (HRCI) as defined by Harvard policy and federal law. I understand that all uses of the Harvard Qualtrics tool for human subjects research must be approved by my IRB, and that I should consult with the Office of the Vice Provost for Research for more information.
+    </p>
+    <label for="disclaimer">Disclaimer</label>
+    <p id="disclaimer">
+    The surveys created or the responses supplied using the survey service do not in any way constitute official Harvard content. The views and opinions expressed are strictly those of the survey&rsquo;s authors. The contents of the surveys and responses have not been reviewed or approved by Harvard.
+    </p>
 
 
 <a href="{% url 'ql:user_accept_terms' %}" class="btn btn-primary">Accept</a>

--- a/qualtrics_link/templates/qualtrics_link/error.html
+++ b/qualtrics_link/templates/qualtrics_link/error.html
@@ -6,7 +6,7 @@
 {% block content %}
 
 <p>
-An error has occured, please try agian or contact <a href="mailto:ithelp@harvard.edu">ithelp@harvard.edu</a> if the problem persistes.
+An error has occured, please try again or contact <a href="mailto:ithelp@harvard.edu">ithelp@harvard.edu</a> if the problem persistes.
 </p>
 
 <p>

--- a/qualtrics_link/views.py
+++ b/qualtrics_link/views.py
@@ -3,18 +3,19 @@ import logging
 import time
 import urllib
 from datetime import date
-
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
 from django.shortcuts import render, redirect
+from django.utils import timezone
 from django.views.decorators.http import require_http_methods
-
-import qualtrics_link.util as util
 from icommons_common.auth.decorators import group_membership_restriction
 from icommons_common.icommonsapi import IcommonsApi
 from icommons_common.monitor.views import BaseMonitorResponseView
+
+import qualtrics_link.util as util
 from qualtrics_link.forms import SpoofForm
+from qualtrics_link.models import Acceptance
 
 logger = logging.getLogger(__name__)
 
@@ -73,22 +74,20 @@ def launch(request):
 
     if user_can_access:
         # Check to see if the user has accepted the terms of service
-        agreement_id = settings.QUALTRICS_LINK.get('AGREEMENT_ID', '260')
-        acceptance_resp = icommons_api.tos_get_acceptance(agreement_id, huid)
-        
-        if acceptance_resp.status_code == 200:
-            acceptance_json = acceptance_resp.json()
-            if 'agreements' in acceptance_json:
-                length = len(acceptance_json['agreements'])
-                if length > 0:
-                    acceptance_text = acceptance_json['agreements'][0]['text']
-                    return render(request, 'qualtrics_link/agreement.html', {'request': request, 'agreement': acceptance_text})
-            else:
-                logger.error('huid: {}, api call returned response code {}'.format(huid, str(acceptance_resp.status_code)))
-                return render(request, 'qualtrics_link/error.html', {'request': request})
-        else:
-            logger.error('huid: {}, api call returned response code {}'.format(huid, str(acceptance_resp.status_code)))
-            return render(request, 'qualtrics_link/error.html', {'request': request})
+
+        user_acceptance = None
+        try:
+            user_acceptance = Acceptance.objects.get(user_id=huid)
+        except Acceptance.DoesNotExist:
+            logger.info('User %s has not  accepted term of service ', huid)
+        except:
+            logger.error('Exception in checking for user acceptance, '
+                         'user_id:%s', huid)
+            return render(request, 'qualtrics_link/error.html')
+
+        #  Render agreement page if user has not accepted term of service
+        if not user_acceptance:
+            return render(request, 'qualtrics_link/agreement.html', {'request': request, 'agreement': "test text"})
 
         enc_id = util.get_encrypted_huid(huid)
         key_value_pairs = u"id={}&timestamp={}&expiration={}&firstname={}&lastname={}&email={}&UserType={}&Division={}"
@@ -165,8 +164,6 @@ def internal(request):
         logger.error('No records with the huid of {} could be found'.format(huid))
         return render(request, 'qualtrics_link/error.html', {'request': request})
 
-    icommons_api = IcommonsApi()
-
     # Check if the user can use qualtrics or not
     # the value of user_can_access is set to False by default
     # if any of the checks here pass we set user_can_access to True
@@ -174,24 +171,24 @@ def internal(request):
         user_can_access = True
     
     if user_can_access:
-        # If they are allowed to use Qualtrics, check to see if the user has accepted the terms of service    
-        agreement_id = settings.QUALTRICS_LINK.get('AGREEMENT_ID')
-        acceptance_resp = icommons_api.tos_get_acceptance(agreement_id, huid)
+        # If they are allowed to use Qualtrics, check to see if the user has accepted the terms of service
+        user_acceptance = None
+        try:
+            user_acceptance = Acceptance.objects.get(user_id=huid)
+        except Acceptance.DoesNotExist:
+            logger.info('User %s has not  accepted term of service ', huid)
+        except:
+            logger.error('Exception in checking for user acceptance, '
+                     'user_id:%s', huid)
+            return render(request, 'qualtrics_link/error.html')
 
-        if acceptance_resp.status_code == 200:
-            acceptance_json = acceptance_resp.json()
-            if 'agreements' in acceptance_json:
-                length = len(acceptance_json['agreements'])
-                if length > 0:
-                    acceptance_text = acceptance_json['agreements'][0]['text']
-                    request.session['spoofid'] = huid
-                    return render(request, 'qualtrics_link/agreement.html', {'request': request, 'agreement': acceptance_text})
-            else:
-                logger.error('Received acceptance status of 200 but could not find any agreements for huid: {}'.format(huid))
-                return render(request, 'qualtrics_link/error.html', {'request': request})
-        else:
-            logger.error('huid: {}, api call returned response code other than 200 {}'.format(huid, acceptance_resp))
-            return render(request, 'qualtrics_link/error.html', {'request': request})
+        #  Render agreement page if user has not accepted term of service
+        if not user_acceptance:
+            request.session['spoofid'] = huid
+            return render(request, 'qualtrics_link/agreement.html', {'request': request, 'agreement': "test text"})
+    # except:
+        #     logger.error('Exception in checking for user acceptance, user_id:%s', huid)
+        #     return render(request, 'qualtrics_link/error.html')
 
         enc_id = util.get_encrypted_huid(huid)
         logline = "{}\t{}\t{}\t{}".format(current_date, client_ip, person_details.role, person_details.division)
@@ -238,15 +235,23 @@ def user_accept_terms(request):
     if not huid:
         huid = request.user.username
 
-    icommons_api = IcommonsApi()
     ip_address = util.get_client_ip(request)
-    params = {'agreementId': '260', 'ipAddress': ip_address}
-    resp = icommons_api.tos_create_acceptance(params, huid)
-    
-    if resp.status_code == 200:
-        logger.info("termsofservice accepted: \t{}\t{}".format(ip_address, '260'))
+    try:
+        print"timezone",  timezone.now()
+        # current_tz = timezone.get_current_timezone()
+        # local = current_tz.normalize(timezone.now())
+        # print "local",local
+        user_acceptance = Acceptance.objects.create(
+            user_id=huid,
+            ip_address=ip_address,
+            acceptance_date=timezone.now() #datetime.now(),
+        )
+        logger.info("termsofservice accepted: \t{}".format(ip_address))
+        # print "user_acceptance=", user_acceptance
         return redirect(settings.QUALTRICS_LINK.get('USER_ACCEPTED_TERMS_URL', 'ql:launch'))
-    
+    except Exception as e:
+        logger.error('Exception saving acceptance for user')
+
     logger.error("Error accepting terms of service")
     return render(request, 'qualtrics_link/error.html', {'request': request})
     
@@ -255,7 +260,7 @@ def user_accept_terms(request):
 @require_http_methods(['GET'])
 def user_decline_terms(request):
     logger.info("User declined terms of service")
-    return redirect(settings.QUALTRICS_LINK.get('USER_DECLINED_TERMS_URL', 'http://surveytools.harvard.edu'))
+    return redirect(settings.QUALTRICS_LINK.get('USER_DECLINED_TERMS_URL'))
 
 
 @require_http_methods(['GET'])

--- a/qualtrics_link/views.py
+++ b/qualtrics_link/views.py
@@ -61,7 +61,7 @@ def launch(request):
     person_details = util.get_person_details(huid)
 
     if person_details is None:
-        logger.error('No records with the huid of {} could be found').format(huid)
+        logger.error('No records with the huid of {} could be found'.format(huid))
         return render(request, 'qualtrics_link/error.html', {'request': request})
 
     # Check if the user can use qualtrics or not

--- a/qualtrics_link/views.py
+++ b/qualtrics_link/views.py
@@ -85,7 +85,8 @@ def launch(request):
 
         #  Render agreement page if user has not accepted term of service
         if not user_acceptance:
-            return render(request, 'qualtrics_link/agreement.html', {'request': request, 'agreement': "test text"})
+            return render(request, 'qualtrics_link/agreement.html',
+                          {'request': request})
 
         enc_id = util.get_encrypted_huid(huid)
         key_value_pairs = u"id={}&timestamp={}&expiration={}&firstname={}&lastname={}&email={}&UserType={}&Division={}"
@@ -175,15 +176,16 @@ def internal(request):
             user_acceptance = Acceptance.objects.get(user_id=huid)
         except Acceptance.DoesNotExist:
             logger.info('User %s has not  accepted term of service ', huid)
-        except:
+        except Exception as e:
             logger.error('Exception in checking for user acceptance, '
-                     'user_id:%s', huid)
+                     'user_id:%s', huid, e)
             return render(request, 'qualtrics_link/error.html')
 
         #  Render agreement page if user has not accepted term of service
         if not user_acceptance:
             request.session['spoofid'] = huid
-            return render(request, 'qualtrics_link/agreement.html', {'request': request, 'agreement': "test text"})
+            return render(request, 'qualtrics_link/agreement.html',
+                          {'request': request})
 
 
         enc_id = util.get_encrypted_huid(huid)

--- a/qualtrics_link/views.py
+++ b/qualtrics_link/views.py
@@ -184,9 +184,7 @@ def internal(request):
         if not user_acceptance:
             request.session['spoofid'] = huid
             return render(request, 'qualtrics_link/agreement.html', {'request': request, 'agreement': "test text"})
-    # except:
-        #     logger.error('Exception in checking for user acceptance, user_id:%s', huid)
-        #     return render(request, 'qualtrics_link/error.html')
+
 
         enc_id = util.get_encrypted_huid(huid)
         logline = "{}\t{}\t{}\t{}".format(current_date, client_ip, person_details.role, person_details.division)
@@ -234,22 +232,17 @@ def user_accept_terms(request):
 
     ip_address = util.get_client_ip(request)
     try:
-        print"timezone",  timezone.now()
-        # current_tz = timezone.get_current_timezone()
-        # local = current_tz.normalize(timezone.now())
-        # print "local",local
+
         user_acceptance = Acceptance.objects.create(
             user_id=huid,
             ip_address=ip_address,
-            acceptance_date=timezone.now() #datetime.now(),
+            acceptance_date=timezone.now()
         )
         logger.info("termsofservice accepted: \t{}".format(ip_address))
-        # print "user_acceptance=", user_acceptance
         return redirect(settings.QUALTRICS_LINK.get('USER_ACCEPTED_TERMS_URL', 'ql:launch'))
     except Exception as e:
-        logger.error('Exception saving acceptance for user')
+        logger.error('Exception saving acceptance for user',e)
 
-    logger.error("Error accepting terms of service")
     return render(request, 'qualtrics_link/error.html', {'request': request})
     
 

--- a/qualtrics_link/views.py
+++ b/qualtrics_link/views.py
@@ -10,7 +10,6 @@ from django.shortcuts import render, redirect
 from django.utils import timezone
 from django.views.decorators.http import require_http_methods
 from icommons_common.auth.decorators import group_membership_restriction
-from icommons_common.icommonsapi import IcommonsApi
 from icommons_common.monitor.views import BaseMonitorResponseView
 
 import qualtrics_link.util as util
@@ -38,7 +37,6 @@ def index(request):
 @login_required
 @require_http_methods(['GET'])
 def launch(request):
-    icommons_api = IcommonsApi()
     user_can_access = False
     client_ip = util.get_client_ip(request)
 
@@ -58,7 +56,7 @@ def launch(request):
     if not huid.isdigit() and not user_in_whitelist:
         logger.info("xidnotauthorized\t{}\t{}".format(current_date, client_ip))
         return render(request, 'qualtrics_link/notauthorized.html', {'request': request})
-    
+
     # The PersonDetails object extends the Person model with additional attributes
     person_details = util.get_person_details(huid)
 
@@ -215,7 +213,6 @@ def internal(request):
             'form': spoof_form
         }
         return render(request, 'qualtrics_link/main.html', context)
-        
     else:
         context = {
             'request': request,


### PR DESCRIPTION
This PR has changes for TLT-3176 - Removed the dependency on the icommonsapi call that handled the user agreement stuff and  moved the  Qualtrics user agreement logic and database table from Oracle db to the qulatrics_link  tool's postgress DB.

Note:  The logic has been simplified and I eliminated the Agreement table and moved the agreement text into the template. The acceptance table is slimmer and has fewer columns. The table creation has been handled with migrations. The data should be transferred over with some sql scripts.   https://jira.huit.harvard.edu/browse/TLT-3183 captures the task for data transfer.

@cmurtaugh , @Chris-Thornton-Harvard 