### PR TITLE
Feature/remove legacy requirements

### DIFF
--- a/icommons_ext_tools/requirements/base.txt
+++ b/icommons_ext_tools/requirements/base.txt
@@ -6,5 +6,6 @@ django-redis-cache==1.7.1
 hiredis==0.2.0
 pycrypto==2.6.1
 redis==2.10.5
+lxml==4.1.1
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.31#egg=django-icommons-common==1.31
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.4#egg=django-icommons-ui==1.4

--- a/icommons_ext_tools/requirements/base.txt
+++ b/icommons_ext_tools/requirements/base.txt
@@ -4,10 +4,7 @@ psycopg2==2.7.3.1
 django-cached-authentication-middleware==0.2.1
 django-redis-cache==1.7.1
 hiredis==0.2.0
-ndg-httpsclient==0.4.2
 pycrypto==2.6.1
 redis==2.10.5
-lxml==3.8.0
-git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.10#egg=canvas-python-sdk==0.10
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.31#egg=django-icommons-common==1.31
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.4#egg=django-icommons-ui==1.4

--- a/icommons_ext_tools/settings/aws.py
+++ b/icommons_ext_tools/settings/aws.py
@@ -4,6 +4,9 @@ from logging.config import dictConfig
 # tlt hostnames
 ALLOWED_HOSTS = ['.tlt.harvard.edu']
 
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = SECURE_SETTINGS['enable_debug']
+
 # Make this unique and don't share with anybody!
 SECRET_KEY = SECURE_SETTINGS['django_secret_key']
 

--- a/icommons_ext_tools/settings/base.py
+++ b/icommons_ext_tools/settings/base.py
@@ -4,13 +4,9 @@ import os
 import logging
 import time
 
-from django.core.urlresolvers import reverse_lazy
 from .secure import SECURE_SETTINGS
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = SECURE_SETTINGS.get('enable_debug', False)
 
 # THESE ADDRESSES WILL RECEIVE EMAIL ABOUT CERTAIN ERRORS!
 # Note: If this list (technically a tuple) has only one element, that

--- a/icommons_ext_tools/settings/base.py
+++ b/icommons_ext_tools/settings/base.py
@@ -8,33 +8,6 @@ from .secure import SECURE_SETTINGS
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-# THESE ADDRESSES WILL RECEIVE EMAIL ABOUT CERTAIN ERRORS!
-# Note: If this list (technically a tuple) has only one element, that
-#       element must be followed by a comma for it to be processed
-#       (cf section 3.2 of https://docs.python.org/2/reference/datamodel.html)
-ADMINS = (
-    ('iCommons Tech', 'icommons-technical@g.harvard.edu'),
-)
-
-MANAGERS = ADMINS
-
-ENV_NAME = SECURE_SETTINGS.get('env_name', 'local')
-
-# This is the address that admin emails (sent to the addresses in the ADMINS list) will be sent 'from'.
-# It can be overridden in specific settings files to indicate what environment
-# is producing admin emails (e.g. 'app env <email>').
-SERVER_EMAIL_DISPLAY_NAME = 'icommons_ext_tools - %s' % ENV_NAME
-SERVER_EMAIL = '%s <%s>' % (SERVER_EMAIL_DISPLAY_NAME, 'icommons-bounces@harvard.edu')
-
-# Email subject prefix is what's shown at the beginning of the ADMINS email subject line
-# Django's default is "[Django] ", which isn't helpful and wastes space in the subject line
-# So this overrides the default and removes that unhelpful [Django] prefix.
-# Specific settings files can override, for example to show the settings file being used:
-# EMAIL_SUBJECT_PREFIX = '[%s] ' % SERVER_EMAIL_DISPLAY_NAME
-# TLT-458: currently the tech_logger inserts its own hostname prefix if available, so this
-#          is not being overridden in environment settings files at present.
-EMAIL_SUBJECT_PREFIX = ''
-
 # Application definition
 
 INSTALLED_APPS = (
@@ -66,10 +39,9 @@ MIDDLEWARE_CLASSES = (
 AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
     'icommons_common.auth.backends.CASAuthBackend',
-
 )
 
-#CAS plugin attributes
+# CAS plugin attributes
 CAS_SERVER_URL = SECURE_SETTINGS.get('cas_server_url', 'https://www.pin1.harvard.edu/cas/')
 CAS_VERSION = '3'
 CAS_LOGGED_MSG = None
@@ -160,7 +132,7 @@ SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 # In a Windows environment this must be set to your system time zone.
 # NOTE: Django 1.7+ project template defaults to UTC time.  This should
 # help Splunk logs.
-TIME_ZONE = 'America/New_York'
+TIME_ZONE = 'UTC'
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
@@ -175,7 +147,7 @@ USE_I18N = False
 USE_L10N = False
 
 # If you set this to False, Django will not use timezone-aware datetimes.
-USE_TZ = False
+USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/


### PR DESCRIPTION
A bit of dependency and minor settings cleanup here:
*  The `ndg-httpsclient` dependency has been removed since it's not needed for Xenial due to the updated system package of the openssl client and it's absence in Trusty should just result in increased log warning messages.
*  The canvas-python-sdk isn't needed anymore and has been removed.
*  The version of lxml has been updated to latest so that it can be installed as a wheel.   It's presence is required by the `python-cas` dependency of `django-cas-ng`.
*   The `DEBUG` setting resolution has been moved to `aws.py` which mirrors the hardcoded setting in `local.py`
*   Email list setup for Django errors has been removed since we currently rely on Splunk for error reporting
*   Timezone setting made to be `UTC` and Django instructed to use timezones.   This shouldn't have an effect on any timestamps saved in Postgres DB, but aligns more with other projects.

