### PR TITLE
Qualtrics User Admin Form Added To Internal Screen

### DIFF
--- a/qualtrics_link/forms.py
+++ b/qualtrics_link/forms.py
@@ -1,5 +1,13 @@
 from django import forms
+from qualtrics_link import util
 
 
 class SpoofForm(forms.Form):
     huid = forms.CharField(max_length=15, required=False)
+
+
+class QualtricsUserAdminForm(forms.Form):
+    division = forms.ChoiceField(choices=util.DIVISION_CHOICES)
+    role = forms.ChoiceField(choices=util.ROLE_CHOICES)
+    manually_updated = forms.ChoiceField(choices=(('True', 'True'), ('False', 'False')))
+

--- a/qualtrics_link/templates/qualtrics_link/main.html
+++ b/qualtrics_link/templates/qualtrics_link/main.html
@@ -116,9 +116,7 @@
 		</div>
 		<input type="hidden" name="huid" value='{{ huid }}'>
 		<div class="col-sm-1">
-			{% if not qualtrics_user_in_db %}
-				<input type="submit" value="Submit" class="btn btn-primary disabled">
-			{% else %}
+			{% if qualtrics_user_in_db %}
 				<input type="submit" value="Submit" class="btn btn-primary">
 			{% endif %}
 

--- a/qualtrics_link/templates/qualtrics_link/main.html
+++ b/qualtrics_link/templates/qualtrics_link/main.html
@@ -114,7 +114,7 @@
 		<div class="col-sm-4">
 			Skip in update job: {{ qualtrics_user_update_form.manually_updated }}
 		</div>
-		<input type="hidden" value='{{ huid }}'>
+		<input type="hidden" name="huid" value='{{ huid }}'>
 		<div class="col-sm-1">
 			{% if not qualtrics_user_in_db %}
 				<input type="submit" value="Submit" class="btn btn-primary disabled">

--- a/qualtrics_link/templates/qualtrics_link/main.html
+++ b/qualtrics_link/templates/qualtrics_link/main.html
@@ -34,7 +34,7 @@
 	}
 
 	.qualtrics_admin {
-		height: 110px;
+		padding-bottom: 50px;
 	}
 
 </style>
@@ -49,7 +49,7 @@
 
 <div class="well spoof-form">
 <h4>Enter an HUID to spoof</h4>
-<form action="internal" method="get" role="form">{% csrf_token %}
+<form action="internal" method="POST" role="form">{% csrf_token %}
 	{% for field in spoof_form %}
 	{{ field.label_tag }}&nbsp;{{ field }}
 	{% endfor %}
@@ -98,7 +98,12 @@
 </table>
 
 <div class="well qualtrics_admin">
-	<h4>Qualtrics Admin For User:</h4>
+	<h4>Manage Qualtrics Division and/or Role</h4>
+	{% if not qualtrics_user_in_db %}
+		<div class="alert alert-warning" role="alert">
+			This user is not currently in out Postgres table. Please contact a dev for further assistance.
+		</div>
+	{% endif %}
 	<form action="internal" method="POST">{% csrf_token %}
 		<div class="col-sm-4">
 			Division: {{ qualtrics_user_update_form.division }}
@@ -107,10 +112,16 @@
 			Role: {{ qualtrics_user_update_form.role }}
 		</div>
 		<div class="col-sm-4">
-			Manually updated: {{ qualtrics_user_update_form.manually_updated }}
+			Skip in update job: {{ qualtrics_user_update_form.manually_updated }}
 		</div>
+		<input type="hidden" value='{{ huid }}'>
 		<div class="col-sm-1">
-			<input type="submit" value="Submit" class="btn btn-primary">
+			{% if not qualtrics_user_in_db %}
+				<input type="submit" value="Submit" class="btn btn-primary disabled">
+			{% else %}
+				<input type="submit" value="Submit" class="btn btn-primary">
+			{% endif %}
+
 		</div>
 	</form>
 </div>

--- a/qualtrics_link/templates/qualtrics_link/main.html
+++ b/qualtrics_link/templates/qualtrics_link/main.html
@@ -29,7 +29,13 @@
 	.title {
 		text-align: center;
 	}
-	.spoof-form { width: 38%; }
+	.spoof-form {
+		width: 38%;
+	}
+
+	.qualtrics_admin {
+		height: 110px;
+	}
 
 </style>
 
@@ -91,22 +97,23 @@
 	</tr>
 </table>
 
-
-<form action="internal" method="POST">{% csrf_token %}
-    <label for="division">Division: </label>
-    <input id="division" type="text" name="division">
-	{{ qualtrics_user_update_form.division }}
-
-	<label for="role">Role: </label>
-    <input id="role" type="text" name="manually_updated">
-	{{ qualtrics_user_update_form.role }}
-
-	<label for="manually_updated">Manually updated: </label>
-    <input id="manually_updated" type="text" name="manually_updated">
-	{{ qualtrics_user_update_form.manually_updated }}
-
-    <input type="submit" value="Submit">
-</form>
+<div class="well qualtrics_admin">
+	<h4>Qualtrics Admin For User:</h4>
+	<form action="internal" method="POST">{% csrf_token %}
+		<div class="col-sm-4">
+			Division: {{ qualtrics_user_update_form.division }}
+		</div>
+		<div class="col-sm-3">
+			Role: {{ qualtrics_user_update_form.role }}
+		</div>
+		<div class="col-sm-4">
+			Manually updated: {{ qualtrics_user_update_form.manually_updated }}
+		</div>
+		<div class="col-sm-1">
+			<input type="submit" value="Submit" class="btn btn-primary">
+		</div>
+	</form>
+</div>
 
 
 {% endblock %}

--- a/qualtrics_link/templates/qualtrics_link/main.html
+++ b/qualtrics_link/templates/qualtrics_link/main.html
@@ -101,7 +101,7 @@
 	<h4>Manage Qualtrics Division and/or Role</h4>
 	{% if not qualtrics_user_in_db %}
 		<div class="alert alert-warning" role="alert">
-			This user is not currently in out Postgres table. Please contact a dev for further assistance.
+			This user is not currently in our Postgres table. Please contact a dev for further assistance.
 		</div>
 	{% endif %}
 	<form action="internal" method="POST">{% csrf_token %}

--- a/qualtrics_link/templates/qualtrics_link/main.html
+++ b/qualtrics_link/templates/qualtrics_link/main.html
@@ -44,7 +44,7 @@
 <div class="well spoof-form">
 <h4>Enter an HUID to spoof</h4>
 <form action="internal" method="get" role="form">{% csrf_token %}
-	{% for field in form %}
+	{% for field in spoof_form %}
 	{{ field.label_tag }}&nbsp;{{ field }}
 	{% endfor %}
 	<input type="submit" value="Submit" class="btn btn-default"/>
@@ -90,6 +90,23 @@
 		</td>
 	</tr>
 </table>
+
+
+<form action="internal" method="POST">{% csrf_token %}
+    <label for="division">Division: </label>
+    <input id="division" type="text" name="division">
+	{{ qualtrics_user_update_form.division }}
+
+	<label for="role">Role: </label>
+    <input id="role" type="text" name="manually_updated">
+	{{ qualtrics_user_update_form.role }}
+
+	<label for="manually_updated">Manually updated: </label>
+    <input id="manually_updated" type="text" name="manually_updated">
+	{{ qualtrics_user_update_form.manually_updated }}
+
+    <input type="submit" value="Submit">
+</form>
 
 
 {% endblock %}

--- a/qualtrics_link/util.py
+++ b/qualtrics_link/util.py
@@ -115,30 +115,38 @@ DIVISION_MAPPING = {
     'GSE-PPE [no longer used]': 'DV_0vsxWeIjXJWeS21'
 }
 
+# Maps the user type to its equivalent Qualtrics ID
+USER_TYPE_MAPPING = {
+    'employee': 'UT_egutew4nqz71QgI',
+    'student': 'UT_787UadC574xhxgU',
+    'brand administrator': 'UT_BRANDADMIN'
+}
+
+
 # Choice tuple used in the Qualtrics internal admin form
 DIVISION_CHOICES = (
+    ('API Div', 'API Div'),
+    ('Berkman', 'Berkman'),
+    ('Central Administration', 'Central Administration'),
+    ('EXT', 'EXT'),
     ('FAS', 'FAS'),
     ('GSE', 'GSE'),
-    ('HSPH', 'HSPH'),
-    ('Other', 'Other'),
-    ('HKS', 'HKS'),
-    ('EXT', 'EXT'),
-    ('HLS', 'HLS'),
-    ('HUIT', 'HUIT'),
+    ('GSE-PPE [no longer used]', 'GSE-PPE [no longer used]'),
     ('GSD', 'GSD'),
-    ('Central Administration', 'Central Administration'),
-    ('HDS', 'HDS'),
     ('HAA (Alumni Assoc.)', 'HAA (Alumni Assoc.)'),
-    ('VPAL Research and Affiliates', 'VPAL Research and Affiliates'),
-    ('Berkman', 'Berkman'),
+    ('HDS', 'HDS'),
+    ('HKS', 'HKS'),
+    ('HLS', 'HLS'),
+    ('HSPH', 'HSPH'),
+    ('HUIT', 'HUIT'),
+    ('Other', 'Other'),
     ('Radcliffe', 'Radcliffe'),
-    ('API Div', 'API Div'),
-    ('GSE-PPE [no longer used]', 'GSE-PPE [no longer used]')
+    ('VPAL Research and Affiliates', 'VPAL Research and Affiliates')
 )
 
 ROLE_CHOICES = (
-    ('employee', 'employee'),
-    ('student', 'student')
+    ('employee', 'Employee'),
+    ('student', 'Student')
 )
 
 BS = 16

--- a/qualtrics_link/util.py
+++ b/qualtrics_link/util.py
@@ -131,7 +131,6 @@ DIVISION_CHOICES = (
     ('EXT', 'EXT'),
     ('FAS', 'FAS'),
     ('GSE', 'GSE'),
-    ('GSE-PPE [no longer used]', 'GSE-PPE [no longer used]'),
     ('GSD', 'GSD'),
     ('HAA (Alumni Assoc.)', 'HAA (Alumni Assoc.)'),
     ('HDS', 'HDS'),

--- a/qualtrics_link/util.py
+++ b/qualtrics_link/util.py
@@ -115,6 +115,32 @@ DIVISION_MAPPING = {
     'GSE-PPE [no longer used]': 'DV_0vsxWeIjXJWeS21'
 }
 
+# Choice tuple used in the Qualtrics internal admin form
+DIVISION_CHOICES = (
+    ('FAS', 'FAS'),
+    ('GSE', 'GSE'),
+    ('HSPH', 'HSPH'),
+    ('Other', 'Other'),
+    ('HKS', 'HKS'),
+    ('EXT', 'EXT'),
+    ('HLS', 'HLS'),
+    ('HUIT', 'HUIT'),
+    ('GSD', 'GSD'),
+    ('Central Administration', 'Central Administration'),
+    ('HDS', 'HDS'),
+    ('HAA (Alumni Assoc.)', 'HAA (Alumni Assoc.)'),
+    ('VPAL Research and Affiliates', 'VPAL Research and Affiliates'),
+    ('Berkman', 'Berkman'),
+    ('Radcliffe', 'Radcliffe'),
+    ('API Div', 'API Div'),
+    ('GSE-PPE [no longer used]', 'GSE-PPE [no longer used]')
+)
+
+ROLE_CHOICES = (
+    ('employee', 'employee'),
+    ('student', 'student')
+)
+
 BS = 16
 pad = lambda s: s + (BS - len(s) % BS) * chr(BS - len(s) % BS)
 


### PR DESCRIPTION
https://jira.huit.harvard.edu/browse/TLT-3232
Demoed to Chrissy and received approval.

Currently deployed to dev.
Since it is pointing to QA RDS for people data and the dev Postgres tables, functionality might not perform as it does when pointing to prod sources. I ran the Qualtrics update job on dev to populate at least 700 records of HUIDS and Qualtrics ID's, so try to use the HUIDS within the qualtrics_user table for testing or I can give a demo while pointing to prod (I use Marlee's account for this).

NOTE: Do not submit the form at the bottom as there is no other environment than prod for making Qualtrics API calls.