### PR TITLE
Feature/log helper

### DIFF
--- a/icommons_ext_tools/requirements/base.txt
+++ b/icommons_ext_tools/requirements/base.txt
@@ -1,5 +1,4 @@
 Django==1.11.9
-django-debug-toolbar==1.9
 cx-Oracle==6.1
 psycopg2==2.7.3.1
 django-cached-authentication-middleware==0.2.1
@@ -8,5 +7,6 @@ hiredis==0.2.0
 pycrypto==2.6.1
 redis==2.10.6
 lxml==4.1.1
+dj-log-config-helper==0.2.3
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.31#egg=django-icommons-common==1.31
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.4#egg=django-icommons-ui==1.4

--- a/icommons_ext_tools/requirements/local.txt
+++ b/icommons_ext_tools/requirements/local.txt
@@ -1,8 +1,9 @@
 # local environment requirements
 
 #includes the base.txt requirements needed in all environments
--r base.txt 
+-r base.txt
 
 # below are requirements specific to the local environment
+django-debug-toolbar==1.9
 django-sslserver==0.19
 mock==2.0.0

--- a/icommons_ext_tools/settings/aws.py
+++ b/icommons_ext_tools/settings/aws.py
@@ -1,5 +1,6 @@
+from dj_log_config_helper import configure_installed_apps_logger
+
 from .base import *
-from logging.config import dictConfig
 
 # tlt hostnames
 ALLOWED_HOSTS = ['.tlt.harvard.edu']
@@ -25,5 +26,10 @@ EMAIL_HOST_PASSWORD = SECURE_SETTINGS.get('email_host_password', '')
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 SESSION_COOKIE_SECURE = True
 
-# make sure dictConfig(LOGGING) stays at the bottom of the file
-dictConfig(LOGGING)
+# Log to file when running in aws
+LOG_LEVEL = SECURE_SETTINGS['log_level']
+LOG_FILE = os.path.join(
+    SECURE_SETTINGS['log_root'], 'django-icommons_ext_tools.log')
+
+configure_installed_apps_logger(
+    LOG_LEVEL, verbose=True, filename=LOG_FILE)

--- a/icommons_ext_tools/settings/base.py
+++ b/icommons_ext_tools/settings/base.py
@@ -10,7 +10,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 
 # Application definition
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django_cas_ng',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -24,9 +24,9 @@ INSTALLED_APPS = (
     'icommons_common.monitor',
     'icommons_ui',
     'qualtrics_link',
-)
+]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE_CLASSES = [
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -34,12 +34,12 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.messages.middleware.MessageMiddleware',
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
-)
+]
 
-AUTHENTICATION_BACKENDS = (
+AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
-    'icommons_common.auth.backends.CASAuthBackend',
-)
+    'icommons_common.auth.backends.CASAuthBackend'
+]
 
 # CAS plugin attributes
 CAS_SERVER_URL = SECURE_SETTINGS.get('cas_server_url', 'https://www.pin1.harvard.edu/cas/')

--- a/icommons_ext_tools/settings/base.py
+++ b/icommons_ext_tools/settings/base.py
@@ -162,80 +162,11 @@ STATIC_URL = '/static/'
 # https://docs.djangoproject.com/en/1.8/topics/logging/#disabling-logging-configuration
 LOGGING_CONFIG = None
 
-_DEFAULT_LOG_LEVEL = SECURE_SETTINGS.get('log_level', 'DEBUG')
-# LOG_ROOT used for log file storage; EMAIL_FILE_PATH used for
-# email output if EMAIL_BACKEND is filebased.EmailBackend
-_LOG_ROOT = SECURE_SETTINGS.get('log_root', '')
-
 # Make sure log timestamps are in GMT
 logging.Formatter.converter = time.gmtime
 
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'formatters': {
-        'verbose': {
-            'format': '%(levelname)s\t%(asctime)s.%(msecs)03dZ\t%(name)s:%(lineno)s\t%(message)s',
-            'datefmt': '%Y-%m-%dT%H:%M:%S'
-        },
-        'simple': {
-            'format': '%(levelname)s\t%(name)s:%(lineno)s\t%(message)s',
-        }
-    },
-    'filters': {
-        'require_debug_false': {
-            '()': 'django.utils.log.RequireDebugFalse'
-        },
-        'require_debug_true': {
-            '()': 'django.utils.log.RequireDebugTrue',
-        },
-    },
-    'handlers': {
-        'default': {
-            'class': 'logging.handlers.WatchedFileHandler',
-            'level': _DEFAULT_LOG_LEVEL,
-            'formatter': 'verbose',
-            'filename': os.path.join(_LOG_ROOT, 'django-icommons_ext_tools.log'),
-        },
-        'console': {
-            'level': _DEFAULT_LOG_LEVEL,
-            'class': 'logging.StreamHandler',
-            'formatter': 'simple',
-            'filters': ['require_debug_true'],
-        },
-    },
-    # This is the default logger for any apps or libraries that use the logger
-    # package, but are not represented in the `loggers` dict below.  A level
-    # must be set and handlers defined.  Setting this logger is equivalent to
-    # setting and empty string logger in the loggers dict below, but the separation
-    # here is a bit more explicit.  See link for more details:
-    # https://docs.python.org/2.7/library/logging.config.html#dictionary-schema-details
-    'root': {
-        'level': logging.WARNING,
-        'handlers': ['default'],
-    },
-    'loggers': {
-        'django': {
-            'level': _DEFAULT_LOG_LEVEL,
-            'filters': ['require_debug_true'],
-            'handlers': ['console', 'default'],
-            'propagate': False,
-        },
-        'qualtrics_link': {
-            'level': _DEFAULT_LOG_LEVEL,
-            'handlers': ['console', 'default'],
-            'propagate': False,
-        },
-        'icommons_common': {
-            'handlers': ['console', 'default'],
-            'level': _DEFAULT_LOG_LEVEL,
-            'propagate': False,
-        },
-    }
-}
 
 # Other app specific settings
-
 
 QUALTRICS_LINK = {
     'AGREEMENT_ID': SECURE_SETTINGS.get('qualtrics_agreement_id'),
@@ -244,6 +175,9 @@ QUALTRICS_LINK = {
     'QUALTRICS_API_USER': SECURE_SETTINGS.get('qualtrics_api_user'),
     'QUALTRICS_API_TOKEN': SECURE_SETTINGS.get('qualtrics_api_token'),
     'QUALTRICS_AUTH_GROUP': SECURE_SETTINGS.get('qualtrics_auth_group'),
-    'USER_DECLINED_TERMS_URL': SECURE_SETTINGS.get('qualtrics_user_declined_terms_url','http://surveytools.harvard.edu'),
-    'USER_ACCEPTED_TERMS_URL': SECURE_SETTINGS.get('qualtrics_user_accepted_terms_url'),
+    'USER_DECLINED_TERMS_URL': SECURE_SETTINGS.get(
+        'qualtrics_user_declined_terms_url',
+        'http://surveytools.harvard.edu'),
+    'USER_ACCEPTED_TERMS_URL': SECURE_SETTINGS.get(
+        'qualtrics_user_accepted_terms_url'),
 }

--- a/icommons_ext_tools/settings/local.py
+++ b/icommons_ext_tools/settings/local.py
@@ -1,18 +1,23 @@
-from .base import *
-from logging.config import dictConfig
+import logging
 
-ALLOWED_HOSTS = ['*']
+from dj_log_config_helper import configure_installed_apps_logger
+
+from .base import *
 
 DEBUG = True
 
 #  Dummy secret key value for testing and local usage
 SECRET_KEY = "==$(1zr5hus_7r@)g4m^t@0qztiqeeeby5%r20q(sa2i^q@-0k"
 
-INSTALLED_APPS += ('debug_toolbar', 'sslserver')
+INSTALLED_APPS.extend(['debug_toolbar', 'sslserver'])
 
-MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+MIDDLEWARE_CLASSES.extend(['debug_toolbar.middleware.DebugToolbarMiddleware'])
 
 # For Django Debug Toolbar:
 INTERNAL_IPS = ('127.0.0.1', '10.0.2.2',)
+DEBUG_TOOLBAR_CONFIG = {
+    'INTERCEPT_REDIRECTS': False,
+}
 
-dictConfig(LOGGING)
+# Log to console when running locally
+configure_installed_apps_logger(logging.DEBUG)

--- a/icommons_ext_tools/settings/local.py
+++ b/icommons_ext_tools/settings/local.py
@@ -14,10 +14,7 @@ INSTALLED_APPS.extend(['debug_toolbar', 'sslserver'])
 MIDDLEWARE_CLASSES.extend(['debug_toolbar.middleware.DebugToolbarMiddleware'])
 
 # For Django Debug Toolbar:
-INTERNAL_IPS = ('127.0.0.1', '10.0.2.2',)
-DEBUG_TOOLBAR_CONFIG = {
-    'INTERCEPT_REDIRECTS': False,
-}
+INTERNAL_IPS = ['127.0.0.1', '10.0.2.2']
 
 # Log to console when running locally
 configure_installed_apps_logger(logging.DEBUG)

--- a/icommons_ext_tools/urls.py
+++ b/icommons_ext_tools/urls.py
@@ -1,16 +1,14 @@
-import django_cas_ng
-from django_cas_ng import views as cas_ng_views
 from django.conf import settings
 from django.conf.urls import url, include
+from django_cas_ng import views as cas_ng_views
 
 from icommons_ui import views as ui_views
-from qualtrics_link import urls as ql_urls
 
 urlpatterns = [
-    url(r'^accounts/login/', django_cas_ng.views.login, name='cas_ng_login'),
-    url(r'^accounts/logout/', django_cas_ng.views.logout, name='cas_ng_logout'),
+    url(r'^accounts/login/', cas_ng_views.login, name='cas_ng_login'),
+    url(r'^accounts/logout/', cas_ng_views.logout, name='cas_ng_logout'),
     url(r'^ext_tools/not_authorized/', ui_views.not_authorized, name="not_authorized"),
-    url(r'^ext_tools/qualtrics_link/', include(ql_urls, namespace="ql")),
+    url(r'^ext_tools/qualtrics_link/', include('qualtrics_link.urls')),
 
 ]
 

--- a/icommons_ext_tools/urls.py
+++ b/icommons_ext_tools/urls.py
@@ -15,10 +15,13 @@ urlpatterns = [
 ]
 
 if settings.DEBUG:
-    import debug_toolbar
-    urlpatterns += [
-        url(r'^__debug__/', include(debug_toolbar.urls)),
-    ]
+    try:
+        import debug_toolbar
+        urlpatterns += [
+            url(r'^__debug__/', include(debug_toolbar.urls)),
+        ]
+    except ImportError:
+        pass  # This is OK for a deployed instance running in DEBUG mode
 
 handler403 = 'icommons_ext_tools.views.handler403'
 handler404 = 'icommons_ext_tools.views.handler404'


### PR DESCRIPTION
Some Django 2.0/1.11 deprecation warning fixes here.   Also, include the `dj-log-config-helper` library to simplify and streamline logging in this project both for local and cloud deployments.