### PR TITLE
TLT-3315 Fix Qualtrics Cron Job

### DIFF
--- a/icommons_ext_tools/cron.d/prod/qualtrics_user_update_cron
+++ b/icommons_ext_tools/cron.d/prod/qualtrics_user_update_cron
@@ -1,2 +1,2 @@
 # Update all required Qualtrics users at 4 am every Sunday
-0 4 * * 0 deploy /home/deploy/.virtualenvs/icommons_ext_tools/bin/python /opt/django/icommons_ext_tools/manage.py qualtrics -perform-full-update >> /var/opt/django/log/django-icommons_ext_tools.log 2>&1
+0 4 * * 0 deploy /home/deploy/.virtualenvs/icommons_ext_tools/bin/python /opt/django/icommons_ext_tools/manage.py qualtrics --perform-full-update >> /var/opt/django/log/django-icommons_ext_tools.log 2>&1

--- a/icommons_ext_tools/cron.d/prod/qualtrics_user_update_cron
+++ b/icommons_ext_tools/cron.d/prod/qualtrics_user_update_cron
@@ -1,2 +1,2 @@
 # Update all required Qualtrics users at 4 am every Sunday
-0 4 * * 0 deploy /home/deploy/.virtualenvs/icommons_ext_tools/bin/python /opt/django/icommons_ext_tools/manage.py qualtrics —perform-full-update >> /var/opt/django/log/django-icommons_ext_tools.log 2>&1
+0 4 * * 0 deploy /home/deploy/.virtualenvs/icommons_ext_tools/bin/python /opt/django/icommons_ext_tools/manage.py qualtrics -perform-full-update >> /var/opt/django/log/django-icommons_ext_tools.log 2>&1


### PR DESCRIPTION
When the management command was run an exception was being thrown regarding an ascii character. This could have been caused by a copy and paste of the line. 
This fix is a manual retype of the cron job