### PR TITLE
Task/sapnamysore/tlt 3310/handle duplicate ids

### DIFF
--- a/qualtrics_link/views.py
+++ b/qualtrics_link/views.py
@@ -193,6 +193,7 @@ def internal(request):
         # Set the initial values of the Qualtrics Admin form
         qualtrics_user_update_form.initial['division'] = person_details.division
         qualtrics_user_update_form.initial['role'] = person_details.role
+        qualtrics_user_update_form.initial['manually_updated'] = False
 
         qualtrics_user_in_db = False
         try:
@@ -200,8 +201,9 @@ def internal(request):
             if qu:
                 qualtrics_user_update_form.initial['manually_updated'] = qu.manually_updated
                 qualtrics_user_in_db = True
-        except QualtricsUser.DoesNotExist:
-            qualtrics_user_update_form.initial['manually_updated'] = False
+        except Exception as ex:
+            logger.info("Exception while finding Qualtrics user", ex)
+
 
 
         enc_id = util.get_encrypted_huid(huid)

--- a/qualtrics_link/views.py
+++ b/qualtrics_link/views.py
@@ -189,16 +189,6 @@ def internal(request):
         user_can_access = True
     
     if user_can_access:
-        # If they are allowed to use Qualtrics, check to see if the user has accepted the terms of service
-        user_acceptance = None
-        try:
-            user_acceptance = Acceptance.objects.get(user_id=huid)
-        except Acceptance.DoesNotExist:
-            logger.info('User %s has not  accepted term of service ', huid)
-        except Exception as e:
-            logger.error('Exception in checking for user acceptance, '
-                     'user_id:%s', huid, e)
-            return render(request, 'qualtrics_link/error.html')
 
         # Set the initial values of the Qualtrics Admin form
         qualtrics_user_update_form.initial['division'] = person_details.division
@@ -212,12 +202,6 @@ def internal(request):
                 qualtrics_user_in_db = True
         except QualtricsUser.DoesNotExist:
             qualtrics_user_update_form.initial['manually_updated'] = False
-
-        # Render agreement page if user has not accepted term of service
-        if not user_acceptance:
-            request.session['spoofid'] = huid
-            return render(request, 'qualtrics_link/agreement.html',
-                          {'request': request})
 
 
         enc_id = util.get_encrypted_huid(huid)

--- a/qualtrics_link/views.py
+++ b/qualtrics_link/views.py
@@ -206,9 +206,10 @@ def internal(request):
 
         qualtrics_user_in_db = False
         try:
-            qu = QualtricsUser.objects.get(univ_id=person_details.id)
-            qualtrics_user_update_form.initial['manually_updated'] = qu.manually_updated
-            qualtrics_user_in_db = True
+            qu = QualtricsUser.objects.filter(univ_id=person_details.id).first()
+            if qu:
+                qualtrics_user_update_form.initial['manually_updated'] = qu.manually_updated
+                qualtrics_user_in_db = True
         except QualtricsUser.DoesNotExist:
             qualtrics_user_update_form.initial['manually_updated'] = False
 


### PR DESCRIPTION

Handled users with  duplicate records.(https://jira.huit.harvard.edu/browse/TLT-3310)
Also noticed that when the 'internal' screen is used to  lookup a user who may not have accepted the 'term of agreement', we are presented the 'Agreement' screen on behalf of the user and would be accepting it as them. Removed that in the workflow (More details and screenshots in Jira ) 