### PR TITLE
Added Tableau Users division

### DIFF
--- a/qualtrics_link/management/commands/qualtrics.py
+++ b/qualtrics_link/management/commands/qualtrics.py
@@ -285,7 +285,8 @@ class Command(BaseCommand):
             'Radcliffe': 'DV_agzgkeDIaZPEJHD',
             'API Div': 'DV_23NVy6XjBHhOXxX',
             'GSE-PPE [no longer used]': 'DV_0vsxWeIjXJWeS21',
-            'HUIT AT': 'DV_9BNfbn5fRIagjkx'
+            'HUIT AT': 'DV_9BNfbn5fRIagjkx',
+            'Tableau Users': 'DV_d59lh2XOCsztQLX'
         }
 
         #####
@@ -327,7 +328,8 @@ class Command(BaseCommand):
             'DV_agzgkeDIaZPEJHD': 'Radcliffe',
             'DV_23NVy6XjBHhOXxX': 'API Div',
             'DV_0vsxWeIjXJWeS21': 'GSE-PPE [no longer used]',
-            'None': 'None'
+            'None': 'None',
+            'DV_d59lh2XOCsztQLX': 'Tableau Users'
         }
         #####
 

--- a/qualtrics_link/util.py
+++ b/qualtrics_link/util.py
@@ -114,7 +114,8 @@ DIVISION_MAPPING = {
     'Radcliffe': 'DV_agzgkeDIaZPEJHD',
     'API Div': 'DV_23NVy6XjBHhOXxX',
     'GSE-PPE [no longer used]': 'DV_0vsxWeIjXJWeS21',
-    'HUIT AT': 'DV_9BNfbn5fRIagjkx'
+    'HUIT AT': 'DV_9BNfbn5fRIagjkx',
+    'Tableau Users': 'DV_d59lh2XOCsztQLX'
 }
 
 # Maps the user type to its equivalent Qualtrics ID
@@ -142,7 +143,8 @@ DIVISION_CHOICES = (
     ('HUIT', 'HUIT'),
     ('Other', 'Other'),
     ('Radcliffe', 'Radcliffe'),
-    ('VPAL Research and Affiliates', 'VPAL Research and Affiliates')
+    ('VPAL Research and Affiliates', 'VPAL Research and Affiliates'),
+    ('Tableau Users', 'Tableau Users')
 )
 
 ROLE_CHOICES = (


### PR DESCRIPTION
Added the "Tableau Users" division to our mapping and drop down menu in the internal dash.
Currently deployed on dev.
I tested using Sapna's HUID and saw the changes reflected in the Qualtrics admin page.