### PR TITLE
modified base.txt to get django_harvardkey-cas tag 1.1 instead of 1.0…

### DIFF
--- a/icommons_ext_tools/requirements/base.txt
+++ b/icommons_ext_tools/requirements/base.txt
@@ -10,5 +10,4 @@ lxml==4.1.1
 dj-log-config-helper==0.2.3
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.31#egg=django-icommons-common==1.31
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.4#egg=django-icommons-ui==1.4
-git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v1.0#egg=django-harvardkey-cas==1.0
-
+git+ssh://git@github.com/Harvard-University-iCommons/django-harvardkey-cas.git@v1.1#egg=django-harvardkey-cas==1.1


### PR DESCRIPTION
… in order for CAS attributes to be handled properly when IAM implements the new CAS endpoint