### PR TITLE
Added support for claspart roles and added a few unit tests

### DIFF
--- a/qualtrics_link/tests.py
+++ b/qualtrics_link/tests.py
@@ -56,6 +56,9 @@ class UtilTestCase(TestCase):
         active_student = Person(role_type_cd='student', role_end_dt=tomorrow)
         active_employee_none_date = Person(role_type_cd='employee', role_end_dt=None)
         active_student_none_date = Person(role_type_cd='student', role_end_dt=None)
+        active_claspart_none_date = Person(role_type_cd='claspart', role_end_dt=None)
+        active_claspart = Person(role_type_cd='claspart', role_end_dt=tomorrow)
+        expired_claspart = Person(role_type_cd='student', role_end_dt=yesterday)
 
         self.assertEqual(util.filter_person_list([expired_employee]).role_type_cd, 'employee')
         self.assertEqual(util.filter_person_list([active_employee_none_date]).role_type_cd, 'employee')
@@ -70,6 +73,9 @@ class UtilTestCase(TestCase):
         self.assertEqual(util.filter_person_list([active_employee, expired_student]).role_type_cd, 'employee')
         self.assertEqual(util.filter_person_list([expired_employee, active_student_none_date]).role_type_cd, 'student')
         self.assertEqual(util.filter_person_list([active_employee_none_date, expired_student]).role_type_cd, 'employee')
+        self.assertEqual(util.filter_person_list([active_claspart_none_date, expired_claspart]).role_type_cd, 'claspart')
+        self.assertEqual(util.filter_person_list([active_claspart, active_student]).role_type_cd, 'student')
+        self.assertEqual(util.filter_person_list([expired_employee, active_claspart]).role_type_cd, 'claspart')
 
         # Do the same tests with the lists reversed
         self.assertEqual(util.filter_person_list([active_student, expired_employee]).role_type_cd, 'student')

--- a/qualtrics_link/util.py
+++ b/qualtrics_link/util.py
@@ -271,8 +271,10 @@ def get_person_with_prime_indicator(person_list):
 def filter_person_list(person_list):
     """
     If there are more than one record returned for a HUID, we want to determine if they contain attributes with priority
-     - Employee
+     - Active Employee
         - If multiple Employee records for HUID, check if the prime role indicator field is set for any of them
+    - Active Student
+    - Active CLASPART
      - Person with prime role indicator field set to 'Y'
      - If no matches are made for the above conditions, return the first person in the given list.   
     """
@@ -295,6 +297,11 @@ def filter_person_list(person_list):
     # Check to see if any of the records are an active Student record
     for person in person_list:
         if person.role_type_cd.lower() == 'student' and (person.role_end_dt is None or person.role_end_dt >= today):
+            return person
+
+    # Check to see if any of the records are an active CLASPART record
+    for person in person_list:
+        if person.role_type_cd.lower() == 'claspart' and (person.role_end_dt is None or person.role_end_dt >= today):
             return person
 
     # Check if any of the Person records contain the prime role indicator


### PR DESCRIPTION
https://jira.huit.harvard.edu/browse/TLT-3585

Seems like most CLASPART records are HBS which does not have access to our instance of Qualtrics. 

To test this:
Find someone with the CLASPART role that should have access to Qualtrics and enter them in the qualtrics internal screen. You should see that they either have a valid school or department. Click the qualtrics survey button to access Qualtrics as that user. 